### PR TITLE
Now properly respecting the maxBatchLimit when talking with peers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2019-06-03
+### Changes
+* Now properly respecting the maxBatchLimit when talking with peers
+
 ## [0.3.1] - 2019-06-03
 ### Changes
 * Minor log wording change when registering etcd pool

--- a/golang/peers.go
+++ b/golang/peers.go
@@ -128,7 +128,7 @@ func (c *PeerClient) run() {
 			queue = append(queue, r)
 
 			// Send the queue if we reached our batch limit
-			if len(queue) > c.conf.BatchLimit {
+			if len(queue) == c.conf.BatchLimit {
 				c.sendQueue(queue)
 				queue = nil
 				continue


### PR DESCRIPTION
## Purpose
Found the following in the logs after deploy to USW2
```ratelimit account-recipients-per-sec error: 'while fetching rate limit 'account-recipients-per-sec_5a255548cd16823c081cce37' from peer - 'rpc error: code = OutOfRange desc = 'PeerRequest.rate_limits' list too large; max size is '1000''' ```