### PR TITLE
configure k8s.io/klog to print messages to stderr

### DIFF
--- a/cmd/gubernator/config.go
+++ b/cmd/gubernator/config.go
@@ -21,18 +21,20 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	etcd "github.com/coreos/etcd/clientv3"
 	"github.com/mailgun/gubernator"
 	"github.com/mailgun/holster"
+	"k8s.io/klog"
 )
 
 var debug = false
@@ -64,6 +66,13 @@ func confFromEnv() (ServerConfig, error) {
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return conf, err
 	}
+
+	// in order to prevent logging to /tmp by k8s.io/client-go
+	// and other kubernetes related dependencies which are using
+	// klog (https://github.com/kubernetes/klog), we need to
+	// initialize klog in the way it prints to stderr only.
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "true")
 
 	if debug || os.Getenv("GUBER_DEBUG") != "" {
 		logrus.SetLevel(logrus.DebugLevel)


### PR DESCRIPTION
Running gubernator in a kubernetes cluster I've encounted a problem that POD restarts because of some weird issue with logging:

```
time="2019-09-04T07:49:42Z" level=debug msg="Debug enabled"
time="2019-09-04T07:49:42Z" level=debug msg="K8s peer pool config found"
time="2019-09-04T07:49:42Z" level=info msg="Gubernator Listening on 0.0.0.0:81 ..." category=server
(main.ServerConfig) {
 GRPCListenAddress: (string) (len=10) "0.0.0.0:81",
 EtcdAdvertiseAddress: (string) (len=12) "127.0.0.1:81",
 HTTPListenAddress: (string) (len=10) "0.0.0.0:80",
 EtcdKeyPrefix: (string) (len=17) "/gubernator-peers",
 CacheSize: (int) 50000,
 EtcdConf: (clientv3.Config) {
  Endpoints: ([]string) (len=1 cap=1) {
   (string) (len=14) "localhost:2379"
  },
  AutoSyncInterval: (time.Duration) 0s,
  DialTimeout: (time.Duration) 5s,
  DialKeepAliveTime: (time.Duration) 0s,
  DialKeepAliveTimeout: (time.Duration) 0s,
  MaxCallSendMsgSize: (int) 0,
  MaxCallRecvMsgSize: (int) 0,
  TLS: (*tls.Config)(<nil>),
  Username: (string) "",
  Password: (string) "",
  RejectOldCluster: (bool) false,
  DialOptions: ([]grpc.DialOption) <nil>,
  Context: (context.Context) <nil>
 },
 Behaviors: (gubernator.BehaviorConfig) {
  BatchTimeout: (time.Duration) 0s,
  BatchWait: (time.Duration) 0s,
  BatchLimit: (int) 0,
  GlobalSyncWait: (time.Duration) 0s,
  GlobalTimeout: (time.Duration) 0s,
  GlobalBatchLimit: (int) 0                                                                                                                                                                                                                                                                                                              
 },                                                                                                                                                                                                                                                                                                                                      
 K8PoolConf: (gubernator.K8sPoolConfig) {
  OnUpdate: (gubernator.UpdateFunc) <nil>,
  Namespace: (string) (len=9) "default",
  Selector: (string) (len=76) "app.kubernetes.io/name=gubernator,app.kubernetes.io/instance=gubernator",
  PodIP: (string) (len=11) "10.48.11.25",
  PodPort: (string) (len=2) "81",
  Enabled: (bool) true
 }
}
time="2019-09-04T07:49:42Z" level=info msg="HTTP Gateway Listening on 0.0.0.0:80 ..." category=server
time="2019-09-04T07:49:43Z" level=debug msg="Queue (Update) 'default/gubernator' - %!s(<nil>)"
time="2019-09-04T07:49:43Z" level=debug msg="Fetching peer list from endpoints API"
time="2019-09-04T07:49:43Z" level=debug msg="Peer: {Address:10.48.11.25:81 IsOwner:true}\n"
time="2019-09-04T07:49:43Z" level=info msg="Peers updated" category=gubernator peers="[{10.48.11.25:81 true}]"
W0904 08:07:25.854825       1 reflector.go:302] pkg/mod/k8s.io/client-go@v0.0.0-20190620085101-78d2af792bab/tools/cache/reflector.go:98: watch of *v1.Endpoints ended with: too old resource version: 62945190 (62948094)                                                                                                                
log: exiting because of error: log: cannot create log: open /tmp/gubernator.gubernator-c5df754d4-fkxpv.unknownuser.log.WARNING.20190904-080725.1: no such file or directory  

```
That was completely unexpected for me, and I've found the cause:

gubernator's dependency `k8s.io/cling-go` is using `k8s.io/klog` for logging. In case this module
will try to log something it will log it into some temporary file (klog is a fork of glog) which terminate the POD (because pod doesn't have `/tmp/`) . 

This PR prevents such behaviour by initialising klog to write everything to stderr.