### PR TITLE
Requests over remaining shouldn't change remaining

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -77,7 +77,7 @@ func tokenBucket(c cache.Cache, r *RateLimitReq) (*RateLimitResp, error) {
 	// Client could be requesting that we always return OVER_LIMIT
 	if r.Hits > r.Limit {
 		status.Status = Status_OVER_LIMIT
-		status.Remaining = 0
+		status.Remaining = r.Limit
 	}
 
 	c.Add(r.HashKey(), status, expire)

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -146,6 +146,10 @@ func (c *LRUCache) Size() int {
 	return c.ll.Len()
 }
 
+func (c *LRUCache) Stats(_ bool) Stats {
+	return c.stats
+}
+
 // Update the expiration time for the key
 func (c *LRUCache) UpdateExpiration(key Key, expireAt int64) bool {
 	if ele, hit := c.cache[key]; hit {


### PR DESCRIPTION
REP-937

Previously there was a disparity between uncached and cached limits when
requesting limit L > remaining R.

* When uncached, R would be set to 0 and OverLimit returned
* When cached, R would be remain R and OverLimit returned

Now, in both instances, R remains unmodified and OverLimit is returned
for that requested limit.