### PR TITLE
PIP-693: GetRateLimits() now handles ErrClosing returned from Peers

### DIFF
--- a/global.go
+++ b/global.go
@@ -223,7 +223,9 @@ func (gm *globalManager) updatePeers(updates map[string]*RateLimitReq) {
 		cancel()
 
 		if err != nil {
-			gm.log.WithError(err).Errorf("error sending global updates to '%s'", peer.host)
+			if err != ErrClosing {
+				gm.log.WithError(err).Errorf("error sending global updates to '%s'", peer.host)
+			}
 			continue
 		}
 	}

--- a/peers.go
+++ b/peers.go
@@ -291,6 +291,4 @@ func (c *PeerClient) Shutdown(ctx context.Context) error {
 	case <-waitChan:
 		return nil
 	}
-
-	return nil
 }


### PR DESCRIPTION
## Purpose
It is possible that while a request is being fulfilled via a peer the peer is removed from the hash ring and it's connection is closed. During this scenario gubernator should attempt to get a new peer and try again.  Related to #28   @joshbohde 