### PR TITLE
ensure we continue after peers (1 or more) were closed successfully

### DIFF
--- a/gubernator.go
+++ b/gubernator.go
@@ -364,10 +364,12 @@ func (s *Instance) SetPeers(peers []PeerInfo) {
 
 	for _, p := range shutdownPeers {
         go func() {
-            err := p.Shutdown(ctx, &wg)
+            err := p.Shutdown(ctx)
             if err != nil {
                 log.WithError(err).WithField("peer", p).Error("while shutting down peer")
             }
+
+    		wg.Done()
         }()
 	}
 

--- a/gubernator.go
+++ b/gubernator.go
@@ -359,13 +359,16 @@ func (s *Instance) SetPeers(peers []PeerInfo) {
 		if peerInfo == nil {
 			shutdownPeers = append(shutdownPeers, p)
 			wg.Add(1)
-			go func() {
-				err := p.Shutdown(ctx)
-				if err != nil {
-					log.WithError(err).WithField("peer", p).Error("while shutting down peer")
-				}
-			}()
 		}
+	}
+
+	for _, p := range shutdownPeers {
+        go func() {
+            err := p.Shutdown(ctx, &wg)
+            if err != nil {
+                log.WithError(err).WithField("peer", p).Error("while shutting down peer")
+            }
+        }()
 	}
 
 	wg.Wait()

--- a/peers.go
+++ b/peers.go
@@ -256,7 +256,7 @@ func (c *PeerClient) sendQueue(queue []*request) {
 }
 
 // Shutdown will gracefully shutdown the client connection, until the context is cancelled
-func (c *PeerClient) Shutdown(ctx context.Context) error {
+func (c *PeerClient) Shutdown(ctx context.Context, wg *sync.WaitGroup) error {
 	// Take the write lock since we're going to modify the closing state
 	c.mutex.Lock()
 	if c.isClosing {
@@ -274,6 +274,8 @@ func (c *PeerClient) Shutdown(ctx context.Context) error {
 		if c.conn != nil {
 			c.conn.Close()
 		}
+
+		wg.Done()
 	}()
 
 	// This allows us to wait on the waitgroup, or until the context

--- a/peers.go
+++ b/peers.go
@@ -256,7 +256,7 @@ func (c *PeerClient) sendQueue(queue []*request) {
 }
 
 // Shutdown will gracefully shutdown the client connection, until the context is cancelled
-func (c *PeerClient) Shutdown(ctx context.Context, wg *sync.WaitGroup) error {
+func (c *PeerClient) Shutdown(ctx context.Context) error {
 	// Take the write lock since we're going to modify the closing state
 	c.mutex.Lock()
 	if c.isClosing {
@@ -274,8 +274,6 @@ func (c *PeerClient) Shutdown(ctx context.Context, wg *sync.WaitGroup) error {
 		if c.conn != nil {
 			c.conn.Close()
 		}
-
-		wg.Done()
 	}()
 
 	// This allows us to wait on the waitgroup, or until the context


### PR DESCRIPTION
This is supposed to fix #34

This is my first ever golang code change so no idea if there is another better way to fix this.

Issue was that the wait statement never completed/returned and as a result new endpoint changes ended up as a pending notification as the current notification never completed: https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go#L638

So this fix explicitly reduces the waitcount after shutting down the peer.
While testing a scenario with stopping multiple instances (2 out of 3) it was also needed to first set the wait count to 2 before starting the go routines.