### PR TITLE
WIP: Support for multi data center peer pickers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,12 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a bug in global behaviour where it would return an error if the async
   update had not occured before the a second request is made. Now it acts like it
   owns the rate limit until the owning node sends an update
-<<<<<<< HEAD
 * Always include reset_time in leaky bucket responses
 * Fixed subtle bug during shutdown where PeerClient passed into goroutine could
   be out of scope/changed when routine runs
-=======
->>>>>>> Added Behavior RESET_REMAINING to reset any hits recorded in the cache for the specified rate limit
 * Behavior is now a flag, this should be a backward compatible change for
   anyone using GLOBAL or NO_BATCHING but will break anyone using
   DURATION_IS_GREGORIAN. Use `HasBehavior()` function to check for behavior

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,9 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a bug in global behaviour where it would return an error if the async
   update had not occured before the a second request is made. Now it acts like it
   owns the rate limit until the owning node sends an update
+<<<<<<< HEAD
 * Always include reset_time in leaky bucket responses
 * Fixed subtle bug during shutdown where PeerClient passed into goroutine could
   be out of scope/changed when routine runs
+=======
+>>>>>>> Added Behavior RESET_REMAINING to reset any hits recorded in the cache for the specified rate limit
 * Behavior is now a flag, this should be a backward compatible change for
   anyone using GLOBAL or NO_BATCHING but will break anyone using
   DURATION_IS_GREGORIAN. Use `HasBehavior()` function to check for behavior

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,10 +31,7 @@ func BenchmarkServer_GetPeerRateLimitNoBatching(b *testing.B) {
 		b.Errorf("SetDefaults err: %s", err)
 	}
 
-	client, err := guber.NewPeerClient(conf.Behaviors, cluster.GetRandomPeer())
-	if err != nil {
-		b.Errorf("NewPeerClient err: %s", err)
-	}
+	client := guber.NewPeerClient(conf.Behaviors, cluster.GetRandomPeer())
 
 	b.Run("GetPeerRateLimitNoBatching", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -54,7 +51,7 @@ func BenchmarkServer_GetPeerRateLimitNoBatching(b *testing.B) {
 }
 
 func BenchmarkServer_GetRateLimit(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetRandomPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}
@@ -80,7 +77,7 @@ func BenchmarkServer_GetRateLimit(b *testing.B) {
 }
 
 func BenchmarkServer_Ping(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetRandomPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}
@@ -108,7 +105,7 @@ func BenchmarkServer_Ping(b *testing.B) {
 }*/
 
 func BenchmarkServer_ThunderingHeard(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetRandomPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,7 +31,7 @@ func BenchmarkServer_GetPeerRateLimitNoBatching(b *testing.B) {
 		b.Errorf("SetDefaults err: %s", err)
 	}
 
-	client, err := guber.NewPeerClient(conf.Behaviors, cluster.GetPeer())
+	client, err := guber.NewPeerClient(conf.Behaviors, cluster.GetRandomPeer())
 	if err != nil {
 		b.Errorf("NewPeerClient err: %s", err)
 	}
@@ -54,7 +54,7 @@ func BenchmarkServer_GetPeerRateLimitNoBatching(b *testing.B) {
 }
 
 func BenchmarkServer_GetRateLimit(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer())
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}
@@ -80,7 +80,7 @@ func BenchmarkServer_GetRateLimit(b *testing.B) {
 }
 
 func BenchmarkServer_Ping(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer())
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}
@@ -108,7 +108,7 @@ func BenchmarkServer_Ping(b *testing.B) {
 }*/
 
 func BenchmarkServer_ThunderingHeard(b *testing.B) {
-	client, err := guber.DialV1Server(cluster.GetPeer())
+	client, err := guber.DialV1Server(cluster.GetRandomPeer())
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}

--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func FromUnixMilliseconds(ts int64) time.Time {
 }
 
 // Given a list of peers, return a random peer
-func RandomPeer(peers []string) string {
+func RandomPeer(peers []PeerInfo) PeerInfo {
 	rand.Shuffle(len(peers), func(i, j int) {
 		peers[i], peers[j] = peers[j], peers[i]
 	})

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -36,11 +36,10 @@ type instance struct {
 func (i *instance) Peers() []gubernator.PeerInfo {
 	var result []gubernator.PeerInfo
 	for _, peer := range peers {
-		info := gubernator.PeerInfo{Address: peer}
-		if peer == i.Address {
-			info.IsOwner = true
+		if peer.Address == i.Address {
+			peer.IsOwner = true
 		}
-		result = append(result, info)
+		result = append(result, peer)
 	}
 	return result
 }
@@ -52,15 +51,15 @@ func (i *instance) Stop() error {
 }
 
 var instances []*instance
-var peers []string
+var peers []gubernator.PeerInfo
 
 // Returns a random peer from the cluster
-func GetPeer() string {
+func GetRandomPeer() gubernator.PeerInfo {
 	return gubernator.RandomPeer(peers)
 }
 
 // Returns a specific peer
-func PeerAt(idx int) string {
+func PeerAt(idx int) gubernator.PeerInfo {
 	return peers[idx]
 }
 
@@ -89,7 +88,7 @@ func StartWith(addresses []string) error {
 		}
 
 		// Add the peers and instances to the package level variables
-		peers = append(peers, ins.Address)
+		peers = append(peers, gubernator.PeerInfo{Address: ins.Address})
 		instances = append(instances, ins)
 	}
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -97,7 +97,7 @@ func TestGetPeer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			peers = tt.peers
-			got := GetPeer()
+			got := GetRandomPeer()
 
 			if !stringInSlice(got, peers) {
 				t.Errorf("expected one of: %v", tt.peers)

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -27,13 +27,13 @@ func Test_instance_Peers(t *testing.T) {
 	tests := []struct {
 		name     string
 		instance *instance
-		peers    []string
+		peers    []gubernator.PeerInfo
 		want     []gubernator.PeerInfo
 	}{
 		{
 			name:     "Happy path",
 			instance: &instance{Address: "mailgun.com"},
-			peers:    []string{"mailgun.com"},
+			peers:    []gubernator.PeerInfo{gubernator.PeerInfo{Address: "mailgun.com"}},
 			want: []gubernator.PeerInfo{
 				{Address: "mailgun.com", IsOwner: true},
 			},
@@ -41,7 +41,7 @@ func Test_instance_Peers(t *testing.T) {
 		{
 			name:     "Get multy peers",
 			instance: &instance{Address: "mailgun.com"},
-			peers:    []string{"localhost:11111", "mailgun.com"},
+			peers:    []gubernator.PeerInfo{gubernator.PeerInfo{Address: "localhost:11111"}, gubernator.PeerInfo{Address: "mailgun.com"}},
 			want: []gubernator.PeerInfo{
 				{Address: "localhost:11111"},
 				{Address: "mailgun.com", IsOwner: true},
@@ -50,7 +50,7 @@ func Test_instance_Peers(t *testing.T) {
 		{
 			name:     "No Peers",
 			instance: &instance{Address: "www.mailgun.com:11111"},
-			peers:    []string{},
+			peers:    []gubernator.PeerInfo{},
 			want:     []gubernator.PeerInfo(nil),
 		},
 		{
@@ -62,7 +62,7 @@ func Test_instance_Peers(t *testing.T) {
 		{
 			name:     "Owner does not exist",
 			instance: &instance{Address: "mailgun.com"},
-			peers:    []string{"localhost:11111"},
+			peers:    []gubernator.PeerInfo{gubernator.PeerInfo{Address: "localhost:11111"}},
 			want: []gubernator.PeerInfo{
 				{Address: "localhost:11111"},
 			},
@@ -82,16 +82,16 @@ func Test_instance_Peers(t *testing.T) {
 func TestGetPeer(t *testing.T) {
 	tests := []struct {
 		name  string
-		peers []string
+		peers []gubernator.PeerInfo
 		oneOf map[string]bool
 	}{
 		{
 			name:  "Happy path",
-			peers: []string{"mailgun.com"},
+			peers: []gubernator.PeerInfo{gubernator.PeerInfo{Address: "mailgun.com"}},
 		},
 		{
 			name:  "Get one peer from multiple peers",
-			peers: []string{"mailgun.com", "localhost", "test.com"},
+			peers: []gubernator.PeerInfo{gubernator.PeerInfo{Address: "mailgun.com"}, gubernator.PeerInfo{Address: "localhost"}, gubernator.PeerInfo{Address: "test.com"}},
 		},
 	}
 	for _, tt := range tests {
@@ -99,19 +99,16 @@ func TestGetPeer(t *testing.T) {
 			peers = tt.peers
 			got := GetRandomPeer()
 
-			if !stringInSlice(got, peers) {
-				t.Errorf("expected one of: %v", tt.peers)
-				t.Errorf("got:             %s", got)
-			}
+			assert.Contains(t, peers, got)
 		})
 	}
 }
 
 func TestPeerAt(t *testing.T) {
-	peers = []string{"mailgun.com"}
+	peers = []gubernator.PeerInfo{gubernator.PeerInfo{Address: "mailgun.com"}}
 
 	got := PeerAt(0)
-	want := "mailgun.com"
+	want := gubernator.PeerInfo{Address: "mailgun.com"}
 
 	assert.Equal(t, want, got)
 }
@@ -186,7 +183,7 @@ func TestStartMultipleInstancesWithAddresses(t *testing.T) {
 	err := StartWith(addresses)
 	assert.Nil(t, err)
 
-	wantPeers := []string{"127.0.0.1:11111", "127.0.0.1:22222"}
+	wantPeers := []gubernator.PeerInfo{gubernator.PeerInfo{Address: "127.0.0.1:11111"}, gubernator.PeerInfo{Address: "127.0.0.1:22222"}}
 	wantInstances := []*instance{
 		{Address: "127.0.0.1:11111"},
 		{Address: "127.0.0.1:22222"},

--- a/etcd.go
+++ b/etcd.go
@@ -28,10 +28,6 @@ import (
 )
 
 type PeerInfo struct {
-	// (Optional) This id is unique within a data center. It identifies which nodes are sisters in a multi data
-	// center config. Leave empty if you don't want to specify sisters or if you are not using multi
-	// data center support.
-	SisterID string
 
 	// (Optional) The name of the data center this peer is in. Leave blank if not using multi data center support.
 	DataCenter string
@@ -45,9 +41,6 @@ type PeerInfo struct {
 
 // Returns the hash key used to identify this peer in the Picker.
 func (p PeerInfo) HashKey() string {
-	if len(p.SisterID) != 0 {
-		return p.SisterID
-	}
 	return p.Address
 }
 

--- a/etcd.go
+++ b/etcd.go
@@ -28,8 +28,27 @@ import (
 )
 
 type PeerInfo struct {
+	// (Optional) This id is unique within a data center. It identifies which nodes are sisters in a multi data
+	// center config. Leave empty if you don't want to specify sisters or if you are not using multi
+	// data center support.
+	SisterID string
+
+	// (Optional) The name of the data center this peer is in. Leave blank if not using multi data center support.
+	DataCenter string
+
+	// (Required) The IP address of the peer which will field peer requests
 	Address string
+
+	// (Optional) Is true if PeerInfo is for this instance of gubernator
 	IsOwner bool
+}
+
+// Returns the hash key used to identify this peer in the Picker.
+func (p PeerInfo) HashKey() string {
+	if len(p.SisterID) != 0 {
+		return p.SisterID
+	}
+	return p.Address
 }
 
 type UpdateFunc func([]PeerInfo)

--- a/functional_test.go
+++ b/functional_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestOverTheLimit(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -95,7 +95,7 @@ func TestOverTheLimit(t *testing.T) {
 }
 
 func TestTokenBucket(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -146,7 +146,7 @@ func TestTokenBucket(t *testing.T) {
 }
 
 func TestLeakyBucket(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -207,7 +207,7 @@ func TestLeakyBucket(t *testing.T) {
 }
 
 func TestMissingFields(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -335,7 +335,7 @@ func TestGlobalRateLimits(t *testing.T) {
 }
 
 func TestChangeLimit(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -423,7 +423,7 @@ func TestChangeLimit(t *testing.T) {
 }
 
 func TestResetRemaining(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
 	require.Nil(t, errs)
 
 	tests := []struct {

--- a/functional_test.go
+++ b/functional_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestOverTheLimit(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -80,10 +80,13 @@ func TestOverTheLimit(t *testing.T) {
 					Duration:  guber.Second,
 					Limit:     2,
 					Hits:      1,
+					Behavior:  0,
 				},
 			},
 		})
 		require.Nil(t, err)
+
+		fmt.Println("got some response")
 
 		rl := resp.Responses[0]
 
@@ -95,7 +98,7 @@ func TestOverTheLimit(t *testing.T) {
 }
 
 func TestTokenBucket(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -146,7 +149,7 @@ func TestTokenBucket(t *testing.T) {
 }
 
 func TestLeakyBucket(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -207,7 +210,7 @@ func TestLeakyBucket(t *testing.T) {
 }
 
 func TestMissingFields(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -271,7 +274,7 @@ func TestMissingFields(t *testing.T) {
 
 func TestGlobalRateLimits(t *testing.T) {
 	peer := cluster.PeerAt(0)
-	client, errs := guber.DialV1Server(peer)
+	client, errs := guber.DialV1Server(peer.Address)
 	require.Nil(t, errs)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
@@ -335,7 +338,7 @@ func TestGlobalRateLimits(t *testing.T) {
 }
 
 func TestChangeLimit(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {
@@ -423,7 +426,7 @@ func TestChangeLimit(t *testing.T) {
 }
 
 func TestResetRemaining(t *testing.T) {
-	client, errs := guber.DialV1Server(cluster.GetRandomPeer())
+	client, errs := guber.DialV1Server(cluster.GetRandomPeer().Address)
 	require.Nil(t, errs)
 
 	tests := []struct {

--- a/global.go
+++ b/global.go
@@ -216,7 +216,7 @@ func (gm *globalManager) updatePeers(updates map[string]*RateLimitReq) {
 
 	for _, peer := range gm.instance.GetPeerList() {
 		// Exclude ourselves from the update
-		if peer.isOwner {
+		if peer.info.IsOwner {
 			continue
 		}
 
@@ -225,8 +225,9 @@ func (gm *globalManager) updatePeers(updates map[string]*RateLimitReq) {
 		cancel()
 
 		if err != nil {
-			if err != ErrClosing {
-				gm.log.WithError(err).Errorf("error sending global updates to '%s'", peer.host)
+			// Skip peers that are not in a ready state
+			if !IsNotReady(err) {
+				gm.log.WithError(err).Errorf("error sending global updates to '%s'", peer.info.Address)
 			}
 			continue
 		}

--- a/global.go
+++ b/global.go
@@ -129,11 +129,11 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 			continue
 		}
 
-		p, ok := peerRequests[peer.host]
+		p, ok := peerRequests[peer.info.Address]
 		if ok {
 			p.req.Requests = append(p.req.Requests, r)
 		} else {
-			peerRequests[peer.host] = &pair{
+			peerRequests[peer.info.Address] = &pair{
 				client: peer,
 				req:    GetPeerRateLimitsReq{Requests: []*RateLimitReq{r}},
 			}
@@ -148,7 +148,7 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 
 		if err != nil {
 			gm.log.WithError(err).
-				Errorf("error sending global hits to '%s'", p.client.host)
+				Errorf("error sending global hits to '%s'", p.client.info.Address)
 			continue
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/mailgun/gubernator
 require (
 	github.com/coreos/etcd v3.3.15+incompatible
 	github.com/davecgh/go-spew v1.1.1
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-gateway v1.10.0
+	github.com/mailgun/holster v3.0.0+incompatible
 	github.com/mailgun/holster/v3 v3.8.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mailgun/holster/v3 v3.8.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
-	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
+	github.com/prometheus/client_model v0.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
+github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0 h1:kRhiuYSXR3+uv2IbVbZhUxK5zVD/2pp3Gd2PpvPkpEo=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -106,6 +108,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mailgun/holster v3.0.0+incompatible h1:bpt8ZCwLBrzjqfBZ5mobNb2NjesNeDHmsOO++Ek9Swc=
+github.com/mailgun/holster v3.0.0+incompatible/go.mod h1:crzolGx27RP/IBT/BnPQiYBB9igmAFHGRrz0zlMP0b0=
 github.com/mailgun/holster/v3 v3.8.1 h1:Z9D3F1ShnxGUlofougjSht08OpIiQKtryBjExB+uz9Q=
 github.com/mailgun/holster/v3 v3.8.1/go.mod h1:rNcFlhMTxFDa1dnQC4sUqI71IpAa9/aPeU6w8IGF3aQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=

--- a/gubernator.go
+++ b/gubernator.go
@@ -186,6 +186,7 @@ func (s *Instance) GetRateLimits(ctx context.Context, r *GetRateLimitsReq) (*Get
 					}
 
 					// Make an RPC call to the peer that owns this rate limit
+					fmt.Println("reaching out to peer")
 					inOut.Out, err = peer.GetPeerRateLimit(ctx, inOut.In)
 					if err != nil {
 						if IsNotReady(err) {
@@ -196,6 +197,8 @@ func (s *Instance) GetRateLimits(ctx context.Context, r *GetRateLimitsReq) (*Get
 							Error: fmt.Sprintf("while fetching rate limit '%s' from peer - '%s'", globalKey, err),
 						}
 					}
+
+					fmt.Println("got data from peer")
 
 					// Inform the client of the owner key of the key
 					inOut.Out.Metadata = map[string]string{"owner": peer.info.Address}

--- a/hash.go
+++ b/hash.go
@@ -60,7 +60,8 @@ func (ch *ConsistantHash) Peers() []*PeerClient {
 
 // Adds a peer to the hash
 func (ch *ConsistantHash) Add(peer *PeerClient) {
-	hash := int(ch.hashFunc([]byte(peer.host)))
+	hash := int(ch.hashFunc([]byte(peer.info.HashKey())))
+
 	ch.peerKeys = append(ch.peerKeys, hash)
 	ch.peerMap[hash] = peer
 	sort.Ints(ch.peerKeys)
@@ -71,9 +72,9 @@ func (ch *ConsistantHash) Size() int {
 	return len(ch.peerKeys)
 }
 
-// Returns the peer by hostname
-func (ch *ConsistantHash) GetPeerByHost(host string) *PeerClient {
-	return ch.peerMap[int(ch.hashFunc([]byte(host)))]
+// Returns the peer by peer info
+func (ch *ConsistantHash) GetByPeerInfo(peer PeerInfo) *PeerClient {
+	return ch.peerMap[int(ch.hashFunc([]byte(peer.HashKey())))]
 }
 
 // Given a key, return the peer that key is assigned too

--- a/interval.go
+++ b/interval.go
@@ -36,7 +36,7 @@ type Interval struct {
 func NewInterval(d time.Duration) *Interval {
 	i := Interval{
 		C:  make(chan struct{}, 1),
-		in: make(chan struct{}),
+		in: make(chan struct{}, 1),
 	}
 	go i.run(d)
 	return &i

--- a/peer_client.go
+++ b/peer_client.go
@@ -24,29 +24,33 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ErrClosing is the error returned when the client is closing
-var ErrClosing = errors.New("closing")
-
 type PeerPicker interface {
-	GetPeerByHost(host string) *PeerClient
+	GetByPeerInfo(PeerInfo) *PeerClient
 	Peers() []*PeerClient
 	Get(string) (*PeerClient, error)
 	New() PeerPicker
 	Add(*PeerClient)
-	Size() int
+	Size() int // TODO: Might not be useful?
 }
 
-type PeerClient struct {
-	client  PeersV1Client
-	conn    *grpc.ClientConn
-	conf    BehaviorConfig
-	queue   chan *request
-	host    string
-	isOwner bool // true if this peer refers to this server instance
+type peerStatus int
 
-	mutex     sync.RWMutex // This mutex is for verifying the closing state of the client
-	isClosing bool
-	wg        sync.WaitGroup // This wait group is to monitor the number of in-flight requests
+const (
+	peerNotConnected peerStatus = iota
+	peerConnected
+	peerClosing
+)
+
+type PeerClient struct {
+	client PeersV1Client
+	conn   *grpc.ClientConn
+	conf   BehaviorConfig
+	queue  chan *request
+	info   PeerInfo
+
+	mutex  sync.RWMutex   // This mutex is for verifying the closing state of the client
+	status peerStatus     // Keep the current status of the peer
+	wg     sync.WaitGroup // This wait group is to monitor the number of in-flight requests
 }
 
 type response struct {
@@ -59,20 +63,57 @@ type request struct {
 	resp    chan *response
 }
 
-func NewPeerClient(conf BehaviorConfig, host string) (*PeerClient, error) {
-	c := &PeerClient{
-		queue: make(chan *request, 1000),
-		host:  host,
-		conf:  conf,
+func NewPeerClient(conf BehaviorConfig, info PeerInfo) *PeerClient {
+	return &PeerClient{
+		queue:  make(chan *request, 1000),
+		status: peerNotConnected,
+		conf:   conf,
+		info:   info,
+	}
+}
+
+// Connect establishes a GRPC connection to a peer
+func (c *PeerClient) Connect() error {
+	// NOTE: To future self, this mutex is used here because we need to know if the peer is disconnecting and
+	// handle ErrClosing. Since this mutex MUST be here we take this opportunity to also see if we are connected.
+	// Doing this here encapsulates managing the connected state to the PeerClient struct. Previously a PeerClient
+	// was connected when `NewPeerClient()` was called however, when adding support for multi data centers having a
+	// PeerClient connected to every Peer in every data center continuously is not desirable, especially if nodes
+	// in each region are configured to all have sisters.
+
+	c.mutex.RLock()
+	if c.status == peerClosing {
+		c.mutex.RUnlock()
+		return &PeerErr{err: errors.New("already disconnecting")}
 	}
 
-	if err := c.dialPeer(); err != nil {
-		return nil, err
+	if c.status == peerNotConnected {
+		// This mutex stuff looks wonky, but it allows us to use RLock() 99% of the time, while the 1% where we
+		// actually need to connect uses a full Lock(), using RLock() most of which should reduce the over head
+		// of a full lock on every call
+
+		// Yield the read lock so we can get the RW lock
+		c.mutex.RUnlock()
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+
+		// Now that we have the RW lock, ensure no else got here ahead of us.
+		if c.status == peerConnected {
+			return nil
+		}
+
+		var err error
+		c.conn, err = grpc.Dial(c.info.Address, grpc.WithInsecure())
+		if err != nil {
+			return &PeerErr{err: errors.Wrapf(err, "failed to dial peer %s", c.info.Address)}
+		}
+		c.client = NewPeersV1Client(c.conn)
+		c.status = peerConnected
+		go c.run()
+		return nil
 	}
-
-	go c.run()
-
-	return c, nil
+	c.mutex.RUnlock()
+	return nil
 }
 
 // GetPeerRateLimit forwards a rate limit request to a peer. If the rate limit has `behavior == BATCHING` configured
@@ -94,12 +135,9 @@ func (c *PeerClient) GetPeerRateLimit(ctx context.Context, r *RateLimitReq) (*Ra
 
 // GetPeerRateLimits requests a list of rate limit statuses from a peer
 func (c *PeerClient) GetPeerRateLimits(ctx context.Context, r *GetPeerRateLimitsReq) (*GetPeerRateLimitsResp, error) {
-	c.mutex.RLock()
-	if c.isClosing {
-		c.mutex.RUnlock()
-		return nil, ErrClosing
+	if err := c.Connect(); err != nil {
+		return nil, err
 	}
-	c.mutex.RUnlock()
 
 	c.wg.Add(1)
 	defer c.wg.Done()
@@ -118,12 +156,9 @@ func (c *PeerClient) GetPeerRateLimits(ctx context.Context, r *GetPeerRateLimits
 
 // UpdatePeerGlobals sends global rate limit status updates to a peer
 func (c *PeerClient) UpdatePeerGlobals(ctx context.Context, r *UpdatePeerGlobalsReq) (*UpdatePeerGlobalsResp, error) {
-	c.mutex.RLock()
-	if c.isClosing {
-		c.mutex.RUnlock()
-		return nil, ErrClosing
+	if err := c.Connect(); err != nil {
+		return nil, err
 	}
-	c.mutex.RUnlock()
 
 	c.wg.Add(1)
 	defer c.wg.Done()
@@ -132,19 +167,14 @@ func (c *PeerClient) UpdatePeerGlobals(ctx context.Context, r *UpdatePeerGlobals
 }
 
 func (c *PeerClient) getPeerRateLimitsBatch(ctx context.Context, r *RateLimitReq) (*RateLimitResp, error) {
-	c.mutex.RLock()
-	if c.isClosing {
-		c.mutex.RUnlock()
-		return nil, ErrClosing
+	if err := c.Connect(); err != nil {
+		return nil, err
 	}
 
 	req := request{request: r, resp: make(chan *response, 1)}
 
 	// Enqueue the request to be sent
 	c.queue <- &req
-
-	// Unlock to prevent the chan from being closed
-	c.mutex.RUnlock()
 
 	c.wg.Add(1)
 	defer c.wg.Done()
@@ -159,18 +189,6 @@ func (c *PeerClient) getPeerRateLimitsBatch(ctx context.Context, r *RateLimitReq
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-}
-
-// dialPeer dials a peer and initializes the GRPC client
-func (c *PeerClient) dialPeer() error {
-	var err error
-	c.conn, err = grpc.Dial(c.host, grpc.WithInsecure())
-	if err != nil {
-		return errors.Wrapf(err, "failed to dial peer %s", c.host)
-	}
-
-	c.client = NewPeersV1Client(c.conn)
-	return nil
 }
 
 // run waits for requests to be queued, when either c.batchWait time
@@ -256,12 +274,12 @@ func (c *PeerClient) sendQueue(queue []*request) {
 func (c *PeerClient) Shutdown(ctx context.Context) error {
 	// Take the write lock since we're going to modify the closing state
 	c.mutex.Lock()
-	if c.isClosing {
+	if c.status == peerClosing || c.status == peerNotConnected {
 		c.mutex.Unlock()
 		return nil
 	}
 
-	c.isClosing = true
+	c.status = peerClosing
 	// We need to close the chan here to prevent a possible race
 	close(c.queue)
 
@@ -288,4 +306,31 @@ func (c *PeerClient) Shutdown(ctx context.Context) error {
 	case <-waitChan:
 		return nil
 	}
+}
+
+// PeerErr is returned if the peer is not connected or is in a closing state
+type PeerErr struct {
+	err error
+}
+
+func (p *PeerErr) NotReady() bool {
+	return true
+}
+
+func (p *PeerErr) Error() string {
+	return p.err.Error()
+}
+
+func (p *PeerErr) Cause() error {
+	return p.err
+}
+
+type notReadyErr interface {
+	NotReady() bool
+}
+
+// IsNotReady returns true if the err is because the peer is not connected or in a closing state
+func IsNotReady(err error) bool {
+	te, ok := err.(notReadyErr)
+	return ok && te.NotReady()
 }

--- a/peer_client_test.go
+++ b/peer_client_test.go
@@ -56,14 +56,14 @@ func TestPeerClientShutdown(t *testing.T) {
 						Behavior: c.Behavior,
 					})
 
-					assert.Contains(t, []error{nil, gubernator.ErrClosing}, err)
+					assert.Contains(t, []error{nil, &gubernator.PeerErr{}}, err)
 				}()
 			}
 
 			// yield the processor that way we allow other goroutines to start their request
 			runtime.Gosched()
 
-			err = client.Shutdown(context.Background())
+			err := client.Shutdown(context.Background())
 			assert.NoError(t, err)
 
 			wg.Wait()

--- a/peer_client_test.go
+++ b/peer_client_test.go
@@ -41,8 +41,7 @@ func TestPeerClientShutdown(t *testing.T) {
 
 		t.Run(c.Name, func(t *testing.T) {
 
-			client, err := gubernator.NewPeerClient(config, cluster.GetPeer())
-			assert.NoError(t, err)
+			client := gubernator.NewPeerClient(config, cluster.GetRandomPeer())
 
 			wg := sync.WaitGroup{}
 			wg.Add(threads)

--- a/region_picker.go
+++ b/region_picker.go
@@ -1,0 +1,59 @@
+package gubernator
+
+type RegionPeerPicker interface {
+	GetClients(string) ([]*PeerClient, error)
+	GetByPeerInfo(PeerInfo) *PeerClient
+	Add(*PeerClient)
+}
+
+// RegionPicker encapsulates pickers for a set of regions
+type RegionPicker struct {
+	// A map of all the pickers by region
+	regions map[string]PeerPicker
+	// The implementation of picker we will use for each region
+	picker PeerPicker
+}
+
+func NewRegionPicker(picker PeerPicker) *RegionPicker {
+	return &RegionPicker{
+		regions: make(map[string]PeerPicker),
+		picker:  picker,
+	}
+}
+
+// TODO: Sending cross DC should mainly update the hits, the config should not be sent, or ignored when received
+// TODO: Calculation of OVERLIMIT should not occur when sending hits cross DC
+
+// GetClients returns all the PeerClients that match this key in all regions
+func (mp *RegionPicker) GetClients(key string) ([]*PeerClient, error) {
+	result := make([]*PeerClient, len(mp.regions))
+	var i int
+	for _, picker := range mp.regions {
+		peer, err := picker.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = peer
+		i++
+	}
+	return result, nil
+}
+
+// GetByPeerInfo returns the first PeerClient the PeerInfo.HasKey() matches
+func (mp *RegionPicker) GetByPeerInfo(info PeerInfo) *PeerClient {
+	for _, picker := range mp.regions {
+		if client := picker.GetByPeerInfo(info); client != nil {
+			return client
+		}
+	}
+	return nil
+}
+
+func (mp *RegionPicker) Add(peer *PeerClient) {
+	picker, ok := mp.regions[peer.info.DataCenter]
+	if !ok {
+		picker = mp.picker.New()
+		mp.regions[peer.info.DataCenter] = picker
+	}
+	picker.Add(peer)
+}


### PR DESCRIPTION
## Purpose
To lay the ground work for multi data center support. This phase refactors the PeerPickers to allow users to specify a DataCenter and Set a SisterID so nodes in different data centers can have sisters they talk too. 

This PR builds on #40 and #41, Merge those first
