### PR TITLE
Fixed race conditions in Peer.Shutdown() and globalManager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ VERSION=$(shell cat version)
 
 LDFLAGS="-X main.Version=$(VERSION)"
 
+test:
+	go test ./... -race -count=1
+
 docker:
 	docker build --build-arg VERSION=$(VERSION) -t thrawn01/gubernator:$(VERSION) .
 	docker tag thrawn01/gubernator:$(VERSION) thrawn01/gubernator:latest

--- a/global.go
+++ b/global.go
@@ -195,13 +195,15 @@ func (gm *globalManager) updatePeers(updates map[string]*RateLimitReq) {
 	var req UpdatePeerGlobalsReq
 	start := time.Now()
 
-	for _, rl := range updates {
+	for _, r := range updates {
+		// Copy the original since we removing the GLOBAL behavior
+		rl := *r
 		// We are only sending the status of the rate limit so
 		// we clear the behavior flag so we don't get queued for update again.
 		SetBehavior(&rl.Behavior, Behavior_GLOBAL, false)
 		rl.Hits = 0
 
-		status, err := gm.instance.getRateLimit(rl)
+		status, err := gm.instance.getRateLimit(&rl)
 		if err != nil {
 			gm.log.WithError(err).Errorf("while sending global updates to peers for: '%s'", rl.HashKey())
 			continue

--- a/interval.go
+++ b/interval.go
@@ -38,7 +38,7 @@ func NewInterval(d time.Duration) *Interval {
 		C:  make(chan struct{}, 1),
 		in: make(chan struct{}),
 	}
-	go i.run(d)
+	i.run(d)
 	return &i
 }
 


### PR DESCRIPTION
## Purpose
Fixes #52  and #51 

## Implementation
TIL: Calling `WaitGroup.Wait()` in separate go routine from `WaitGroup.Add(1)` could cause a race condition if go routine that calls `WaitGroup.Wait()` is called before or at the same time `WaitGroup.Add(1)` is called. 