### PR TITLE
added extended k8s options:

### DIFF
--- a/config.go
+++ b/config.go
@@ -316,6 +316,12 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile string) (DaemonConfig, 
 	conf.K8PoolConf.PodIP = os.Getenv("GUBER_K8S_POD_IP")
 	conf.K8PoolConf.PodPort = os.Getenv("GUBER_K8S_POD_PORT")
 	conf.K8PoolConf.Selector = os.Getenv("GUBER_K8S_ENDPOINTS_SELECTOR")
+	var assignErr error
+	conf.K8PoolConf.Mechanism, assignErr = WatchMechanismFromString(os.Getenv("GUBER_K8S_WATCH_MECHANISM"))
+	if assignErr != nil {
+		return conf, errors.New("invalid value for watch mechanism " +
+			"`GUBER_K8S_WATCH_MECHANISM` needs to be either 'endpoints' or 'watch' or empty(defaulting to 'endpoints'))")
+	}
 
 	// PeerPicker Config
 	if pp := os.Getenv("GUBER_PEER_PICKER"); pp != "" {

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/memberlist v0.2.0 h1:WeeNspppWi5s1OFefTviPQueC/Bq8dONfvNjPhiEQKE=
 github.com/hashicorp/memberlist v0.2.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/kubernetesconfig.go
+++ b/kubernetesconfig.go
@@ -1,0 +1,11 @@
+// +build !local
+
+package gubernator
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+func RestConfig() (*rest.Config, error) {
+	return rest.InClusterConfig()
+}

--- a/kubernetesconfig_local.go
+++ b/kubernetesconfig_local.go
@@ -1,0 +1,38 @@
+// +build local
+
+package gubernator
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+
+func config() (*rest.Config, error) {
+	home := homeDir()
+	if home == "" {
+		return nil, errors.New("could not find kube config file. cannot load config")
+
+	}
+	cfg := filepath.Join(home, ".kube", "config")
+	r, err := clientcmd.BuildConfigFromFlags("", cfg)
+	if nil != err {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func RestConfig() (*rest.Config, error) {
+	return config()
+}


### PR DESCRIPTION
at sixt, where we are using gubernator already ( and want to use it even more in the future ), we do not have kubernetes services for each of our services. so i added a mechanism that allows to watch for pods directly instead of endpoints. the default behavior however, will not change. 

also we can build/run gubernator with "-tags local" now which lets us test gubernator locally more easily without having to deploy it to the cluster. 

-can specify whether we watch for pods or endpoints while keeping the default behavior
-can run gubernator with -tags local to make use of local k8s config
-update peer list in add function again to get initial list of peers