### PR TITLE
Fix leaky bucket algorithm returning remaining more than limit

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -235,13 +235,13 @@ func leakyBucket(s Store, c Cache, r *RateLimitReq) (resp *RateLimitResp, err er
 		elapsed := now - b.UpdatedAt
 		leak := float64(elapsed) / rate
 
-		if int64(b.Remaining) > b.Limit {
-			b.Remaining = float64(b.Limit)
-		}
-
 		if int64(leak) > 0 {
 			b.Remaining += leak
 			b.UpdatedAt = now
+		}
+
+		if int64(b.Remaining) > b.Limit {
+			b.Remaining = float64(b.Limit)
 		}
 
 		rl := &RateLimitResp{


### PR DESCRIPTION
I noticed that the leaky bucket algorithm was returning the limit response with the `remaining` value more than the `limit`, which turns out is because the max is set before adding the `leak` to the `remaining` so I've make a simple change and added a test case for it.

Please let me know if anything should change or if this is not the expected behavior.