### PR TITLE
add max conn age support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.pyc
 gubernator.egg-info/
 .DS_Store
+*.iml

--- a/config.go
+++ b/config.go
@@ -159,6 +159,10 @@ type DaemonConfig struct {
 	// (Required) The `address:port` that will accept HTTP requests
 	HTTPListenAddress string
 
+	// (Optional) Defines the max age connection from client in seconds.
+	// Default is infinity
+	GRPCMaxConnectionAgeSeconds int64
+
 	// (Optional) The `address:port` that is advertised to other Gubernator peers.
 	// Defaults to `GRPCListenAddress`
 	AdvertiseAddress string
@@ -233,6 +237,7 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile string) (DaemonConfig, 
 	// Main config
 	setter.SetDefault(&conf.GRPCListenAddress, os.Getenv("GUBER_GRPC_ADDRESS"), "localhost:81")
 	setter.SetDefault(&conf.HTTPListenAddress, os.Getenv("GUBER_HTTP_ADDRESS"), "localhost:80")
+	setter.SetDefault(&conf.GRPCMaxConnectionAgeSeconds, os.Getenv("GUBER_GRPC_MAX_CONN_AGE_SEC"), 0)
 	setter.SetDefault(&conf.CacheSize, getEnvInteger(log, "GUBER_CACHE_SIZE"), 50_000)
 	setter.SetDefault(&conf.AdvertiseAddress, os.Getenv("GUBER_ADVERTISE_ADDRESS"), conf.GRPCListenAddress)
 	setter.SetDefault(&conf.DataCenter, os.Getenv("GUBER_DATA_CENTER"), "")

--- a/config.go
+++ b/config.go
@@ -161,7 +161,7 @@ type DaemonConfig struct {
 
 	// (Optional) Defines the max age connection from client in seconds.
 	// Default is infinity
-	GRPCMaxConnectionAgeSeconds int64
+	GRPCMaxConnectionAgeSeconds int
 
 	// (Optional) The `address:port` that is advertised to other Gubernator peers.
 	// Defaults to `GRPCListenAddress`
@@ -237,7 +237,7 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile string) (DaemonConfig, 
 	// Main config
 	setter.SetDefault(&conf.GRPCListenAddress, os.Getenv("GUBER_GRPC_ADDRESS"), "localhost:81")
 	setter.SetDefault(&conf.HTTPListenAddress, os.Getenv("GUBER_HTTP_ADDRESS"), "localhost:80")
-	setter.SetDefault(&conf.GRPCMaxConnectionAgeSeconds, os.Getenv("GUBER_GRPC_MAX_CONN_AGE_SEC"), 0)
+	setter.SetDefault(&conf.GRPCMaxConnectionAgeSeconds, getEnvInteger(log, "GUBER_GRPC_MAX_CONN_AGE_SEC"), 0)
 	setter.SetDefault(&conf.CacheSize, getEnvInteger(log, "GUBER_CACHE_SIZE"), 50_000)
 	setter.SetDefault(&conf.AdvertiseAddress, os.Getenv("GUBER_ADVERTISE_ADDRESS"), conf.GRPCListenAddress)
 	setter.SetDefault(&conf.DataCenter, os.Getenv("GUBER_DATA_CENTER"), "")

--- a/daemon.go
+++ b/daemon.go
@@ -22,6 +22,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
+
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/mailgun/holster/v3/etcdutil"
@@ -84,6 +87,13 @@ func (s *Daemon) Start(ctx context.Context) error {
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(s.statsHandler),
 		grpc.MaxRecvMsgSize(1024 * 1024),
+	}
+
+	if s.conf.GRPCMaxConnectionAgeSeconds > 0 {
+		opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionAge:      time.Second * time.Duration(s.conf.GRPCMaxConnectionAgeSeconds),
+			MaxConnectionAgeGrace: time.Second * time.Duration(s.conf.GRPCMaxConnectionAgeSeconds),
+		}))
 	}
 
 	if err := SetupTLS(s.conf.TLS); err != nil {

--- a/example.conf
+++ b/example.conf
@@ -17,6 +17,11 @@ GUBER_HTTP_ADDRESS=0.0.0.0:9980
 # to guess at a non loopback interface
 GUBER_ADVERTISE_ADDRESS=localhost:9990
 
+# Time in seconds that the server will keep a client connection alive
+#
+# If value is zero (default) time is infinity
+# GUBER_GRPC_MAX_CONN_AGE_SEC=30
+
 # Max size of the cache; This is the cache that holds
 # all the rate limits. The cache size will never grow
 # beyond this size.

--- a/gubernator.go
+++ b/gubernator.go
@@ -53,7 +53,6 @@ func NewV1Instance(conf Config) (*V1Instance, error) {
 	if conf.GRPCServers == nil {
 		return nil, errors.New("at least one GRPCServer instance is required")
 	}
-
 	if err := conf.SetDefaults(); err != nil {
 		return nil, err
 	}

--- a/k8s-deployment.yaml
+++ b/k8s-deployment.yaml
@@ -57,6 +57,11 @@ spec:
           # Enable debug for diagnosing issues
           - name: GUBER_DEBUG
             value: "true"
+          # Defines the max age of a client connection
+          # Default is infinity
+          # - name: GUBER_GRPC_MAX_CONN_AGE_SEC
+          #  value: "30"
+
       restartPolicy: Always
 ---
 apiVersion: v1


### PR DESCRIPTION
Hello Guys, this PR add support to configure max conn age in grpc server.

It's very important to do a loadbalancing in kubernetes, once the server will renew the connections and force to redirect to others pods.

Regards.