### PR TITLE
Performance improvements in GetRateLimits()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-rc.5] - 2021-06-03
+## Changes
+* Implemented performance recommendations reported in Issue #74
+
+## [2.0.0-rc.4] - 2021-06-03
+## Changes
+* Add support for burst in leaky bucket #103
+* Add working example of aws ecs service discovery deployment #102
+
 ## [2.0.0-rc.2] - 2021-07-11
 ## Changes
 * Deprecated github.com/golang/protobuf was replaced with google.golang.org/protobuf

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -79,6 +79,33 @@ func BenchmarkServer_GetRateLimit(b *testing.B) {
 	})
 }
 
+func BenchmarkServer_GetRateLimitGlobal(b *testing.B) {
+	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
+	if err != nil {
+		b.Errorf("NewV1Client err: %s", err)
+	}
+
+	b.Run("GetRateLimitGlobal", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			_, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
+				Requests: []*guber.RateLimitReq{
+					{
+						Name:      "get_rate_limit_benchmark",
+						UniqueKey: guber.RandomString(10),
+						Behavior:  guber.Behavior_GLOBAL,
+						Limit:     10,
+						Duration:  guber.Second * 5,
+						Hits:      1,
+					},
+				},
+			})
+			if err != nil {
+				b.Errorf("client.RateLimit() err: %s", err)
+			}
+		}
+	})
+}
+
 func BenchmarkServer_Ping(b *testing.B) {
 	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
 	if err != nil {
@@ -107,13 +134,13 @@ func BenchmarkServer_Ping(b *testing.B) {
 	}
 }*/
 
-func BenchmarkServer_ThunderingHeard(b *testing.B) {
+func BenchmarkServer_ThunderingHerd(b *testing.B) {
 	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
 	if err != nil {
 		b.Errorf("NewV1Client err: %s", err)
 	}
 
-	b.Run("ThunderingHeard", func(b *testing.B) {
+	b.Run("ThunderingHerd", func(b *testing.B) {
 		fan := syncutil.NewFanOut(100)
 		for n := 0; n < b.N; n++ {
 			fan.Run(func(o interface{}) error {


### PR DESCRIPTION
## Purpose
To incorporate the performance improvements recommended in #74 Comments by @valer-cara 

## Implementation
* GetRateLimits() now processes requests synchronously until the key is found to belong to a remote instance. A go-routine is then spawned to handle the remote call. 

## Results
While the change did show an improvement, I didn't see the huge improvement I was expecting in `GetRateLimit` tests. The biggest improvement is in the `ThunderingHerd` tests where there is almost a 1x improvement. Users should notice the greatest improvement for rate limits when using `Behavior = GLOBAL` and making many concurrent requests.

```
== Master ==
BenchmarkServer_GetPeerRateLimitNoBatching
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching-12            10000    108844 ns/op
BenchmarkServer_GetRateLimit
BenchmarkServer_GetRateLimit/GetRateLimit
BenchmarkServer_GetRateLimit/GetRateLimit-12                                         1581    778386 ns/op
BenchmarkServer_GetRateLimitGlobal
BenchmarkServer_GetRateLimitGlobal/GetRateLimitGlobal
BenchmarkServer_GetRateLimitGlobal/GetRateLimitGlobal-12                             4720    248670 ns/op
BenchmarkServer_Ping
BenchmarkServer_Ping/HealthCheck
BenchmarkServer_Ping/HealthCheck-12                                                 13084     90224 ns/op
BenchmarkServer_ThunderingHeard
BenchmarkServer_ThunderingHeard/ThunderingHeard
BenchmarkServer_ThunderingHeard/ThunderingHeard-12                                  45579     26908 ns/op

== Performance Improvements ==
BenchmarkServer_GetPeerRateLimitNoBatching
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching-12            11348    102626 ns/op
BenchmarkServer_GetRateLimit
BenchmarkServer_GetRateLimit/GetRateLimit
BenchmarkServer_GetRateLimit/GetRateLimit-12                                         1612    739589 ns/op
BenchmarkServer_GetRateLimitGlobal
BenchmarkServer_GetRateLimitGlobal/GetRateLimitGlobal
BenchmarkServer_GetRateLimitGlobal/GetRateLimitGlobal-12                             5185    199153 ns/op
BenchmarkServer_Ping
BenchmarkServer_Ping/HealthCheck
BenchmarkServer_Ping/HealthCheck-12                                                 13460     89366 ns/op
BenchmarkServer_ThunderingHerd
BenchmarkServer_ThunderingHerd/ThunderingHerd
BenchmarkServer_ThunderingHerd/ThunderingHerd-12                                    76543     16422 ns/op
```