### PR TITLE
Pool via dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ Example response:
 ```
 
 ### Deployment
-NOTE: Gubernator uses etcd or kubernetes to discover peers and establish a cluster. If you
-don't have either, the docker-compose method is the simplest way to try gubernator out.
+NOTE: Gubernator uses `etcd` or Kubernetes or round-robin DNS to discover peers and
+establish a cluster. If you don't have either, the docker-compose method is the
+simplest way to try gubernator out.
 
 ##### Docker with existing etcd cluster
 ```bash
@@ -286,6 +287,21 @@ $ vi k8s-deployment.yaml
 # Create the deployment (includes headless service spec)
 $ kubectl create -f k8s-deployment.yaml
 ```
+
+##### Round-robin DNS
+If your DNS service supports auto-registration, for example AWS Route53 service discovery,
+you can use same fully-qualified domain name to both let your business logic containers or
+instances to find `gubernator` and for `gubernator` containers/instances to find each other.
+
+###### Local Testing
+
+1. terminal, start the environment: `docker-compose -f docker-compose-dns.yml up --build`
+2. terminal, drop into test container: `docker exec -it gubernator_shell_1 /bin/sh`
+3. in the test container: `curl -v gubernator/v1/GetRateLimits --data '{"requests":[{"name":"requests_per_sec","unique_key":"account.id=1234","hits":1,"duration":60000,"limit":10}]}'
+
+###### AWS
+
+TBD
 
 ##### TLS
 Gubernator supports TLS for both HTTP and GRPC connections. You can see an example with

--- a/daemon.go
+++ b/daemon.go
@@ -182,6 +182,12 @@ func (s *Daemon) Start(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "while creating etcd pool")
 		}
+	case "dns":
+		s.conf.DNSPoolConf.OnUpdate = s.V1Server.SetPeers
+		s.pool, err = NewDNSPool(s.conf.DNSPoolConf)
+		if err != nil {
+			return errors.Wrap(err, "while creating the DNS pool")
+		}
 	case "member-list":
 		s.conf.MemberListPoolConf.OnUpdate = s.V1Server.SetPeers
 		s.conf.MemberListPoolConf.Logger = s.log

--- a/dns.go
+++ b/dns.go
@@ -1,0 +1,202 @@
+package gubernator
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"os"
+	"time"
+
+	"github.com/mailgun/holster/v4/setter"
+	"github.com/miekg/dns"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Adapted from TimothyYe/godns
+// DNSResolver represents a dns resolver
+type DNSResolver struct {
+	Servers []string
+	random  *rand.Rand
+}
+
+// NewFromResolvConf initializes DnsResolver from resolv.conf like file.
+func NewFromResolvConf(path string) (*DNSResolver, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return &DNSResolver{}, errors.New("no such file or directory: " + path)
+	}
+
+	config, err := dns.ClientConfigFromFile(path)
+	if err != nil {
+		return &DNSResolver{}, err
+	}
+
+	var servers []string
+	if len(config.Servers) == 0 {
+		return &DNSResolver{}, errors.New("no servers in config")
+	}
+	for _, ipAddress := range config.Servers {
+		servers = append(servers, net.JoinHostPort(ipAddress, "53"))
+	}
+	return &DNSResolver{servers, rand.New(rand.NewSource(time.Now().UnixNano()))}, nil
+}
+
+func (r *DNSResolver) lookupHost(host string, dnsType uint16, delay uint32) ([]net.IP, uint32, error) {
+	m1 := new(dns.Msg)
+	m1.Id = dns.Id()
+	m1.RecursionDesired = true
+	m1.Question = make([]dns.Question, 1)
+
+	switch dnsType {
+	case dns.TypeA:
+		m1.Question[0] = dns.Question{Name: dns.Fqdn(host), Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	case dns.TypeAAAA:
+		m1.Question[0] = dns.Question{Name: dns.Fqdn(host), Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	}
+
+	in, err := dns.Exchange(m1, r.Servers[r.random.Intn(len(r.Servers))])
+
+	var result []net.IP
+
+	if err != nil {
+		return result, 0, err
+	}
+
+	if in.Rcode != dns.RcodeSuccess {
+		return result, 0, errors.New(dns.RcodeToString[in.Rcode])
+	}
+
+	if dnsType == dns.TypeA {
+		if len(in.Answer) > 0 {
+			for _, record := range in.Answer {
+				if t, ok := record.(*dns.A); ok {
+					result = append(result, t.A)
+					delay = min(delay, record.Header().Ttl)
+				}
+			}
+		} else {
+			return result, 0, errors.New("not useful")
+		}
+	}
+
+	if dnsType == dns.TypeAAAA {
+		if len(in.Answer) > 0 {
+			for _, record := range in.Answer {
+				if t, ok := record.(*dns.AAAA); ok {
+					result = append(result, t.AAAA)
+					delay = min(delay, record.Header().Ttl)
+				}
+			}
+		} else {
+			return result, 0, errors.New("not useful")
+		}
+	}
+
+	return result, delay, nil
+}
+
+type DNSPoolConfig struct {
+	// (Required) The FQDN that should resolve to gubernator instance ip addresses
+	FQDN string
+
+	// (Required) Filesystem path to "/etc/resolv.conf", override for testing, @thrawn01 insisted
+	ResolvConf string
+
+	// (Required) Own GRPC address
+	OwnAddress string
+
+	// (Required) Called when the list of gubernators in the pool updates
+	OnUpdate UpdateFunc
+
+	Logger logrus.FieldLogger
+}
+
+type DNSPool struct {
+	log    logrus.FieldLogger
+	conf   DNSPoolConfig
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewDNSPool(conf DNSPoolConfig) (*DNSPool, error) {
+	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))
+
+	if conf.OwnAddress == "" {
+		return nil, errors.New("Advertise.GRPCAddress is required")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &DNSPool{
+		log:    conf.Logger,
+		conf:   conf,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	go pool.task()
+	return pool, nil
+}
+
+func peer(ip string, self string, ipv6 bool) PeerInfo {
+
+	if ipv6 {
+		ip = "[" + ip + "]"
+	}
+	grpc := ip + ":81"
+	return PeerInfo{
+		DataCenter:  "",
+		HTTPAddress: ip + ":80",
+		GRPCAddress: grpc,
+		IsOwner:     grpc == self,
+	}
+
+}
+
+func min(a uint32, b uint32) uint32 {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
+func (p *DNSPool) task() {
+	for {
+		var delay uint32 = 300
+		resolver, err := NewFromResolvConf(p.conf.ResolvConf)
+		if err != nil {
+			p.log.Warn("No resolver: ", err)
+
+		} else {
+			ipv4, delay4, err4 := resolver.lookupHost(p.conf.FQDN, dns.TypeA, delay)
+			ipv6, delay6, err6 := resolver.lookupHost(p.conf.FQDN, dns.TypeAAAA, delay)
+			var update []PeerInfo
+			if err4 == nil {
+				delay = min(delay, delay4)
+				for _, ip := range ipv4 {
+					update = append(update, peer(ip.String(), p.conf.OwnAddress, false))
+				}
+			}
+			if err6 == nil {
+				delay = min(delay, delay6)
+				for _, ip := range ipv6 {
+					update = append(update, peer(ip.String(), p.conf.OwnAddress, false))
+				}
+			}
+			if len(update) > 0 {
+				p.conf.OnUpdate(update)
+			} else {
+				p.log.Error("Looking up peers: ", err4, err6)
+			}
+		}
+		p.log.Debug("DNS poll delay: ", delay)
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-time.After(time.Duration(delay) * time.Second):
+		}
+	}
+}
+
+func (p *DNSPool) Close() {
+	p.cancel()
+}

--- a/docker-compose-dns.yml
+++ b/docker-compose-dns.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+
+services:
+  gubernator:
+    # FIXME update after merge when new image is built from thrawn01 repo
+    image: dimaqq/gubernator:test
+    environment:
+      GUBER_PEER_DISCOVERY_TYPE: dns
+      # Docker will resolve replica addresses by the service name, `gubernator`
+      GUBER_DNS_FQDN: gubernator
+      GUBER_GRPC_ADDRESS: 0.0.0.0:81
+      GUBER_HTTP_ADDRESS: 0.0.0.0:80
+      GUBER_DEBUG: 1
+    deploy:
+      mode: replicated
+      replicas: 2
+      endpoint_mode: dnsrr
+    networks:
+      - vpc
+  shell:
+    # docker exec -it into this container to poke gubernator instances
+    image: praqma/network-multitool
+    command: sleep 3600
+    init: true
+    networks:
+      - vpc
+
+networks:
+  vpc:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/hashicorp/memberlist v0.2.4
 	github.com/mailgun/holster/v4 v4.0.0
+	github.com/miekg/dns v1.1.43
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.42 h1:gWGe42RGaIqXQZ+r3WUGEKBEtvPHY2SXo4dqixDNxuY=
 github.com/miekg/dns v1.1.42/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
+github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=


### PR DESCRIPTION
#### Summary

This PR brings a new deployment option:
The cloud offers a DNS service with service discovery.
For example in AWS, it's a multi-value DNS entry, where when each new container or instance (from a particular group) is started, an A (and maybe AAAA) record is added to the predefined FQDN. When a container or instance is terminated, it's A (or AAAA) record is automatically removed.
The `gubernator` clients when only need to "talk" to the FQDN to rate limit.
The `gubernator` instances can query this FQDN to discover their neighbours.

Clouds:
* AWS should work (currently testing)
* GCP no idea
* Azure no idea

#### to do
- [x] code
- [ ] ~~unit tests?~~
- [x] manual testing 
- [x] docs