### PR TITLE
WIP: Multi-Region

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -52,6 +52,12 @@ func TestMain(m *testing.M) {
 		{GRPCAddress: "127.0.0.1:9891", HTTPAddress: "127.0.0.1:9881", DataCenter: cluster.DataCenterOne},
 		{GRPCAddress: "127.0.0.1:9892", HTTPAddress: "127.0.0.1:9882", DataCenter: cluster.DataCenterOne},
 		{GRPCAddress: "127.0.0.1:9893", HTTPAddress: "127.0.0.1:9883", DataCenter: cluster.DataCenterOne},
+
+		// DataCenterTwo
+		{GRPCAddress: "127.0.0.1:9790", HTTPAddress: "127.0.0.1:9780", DataCenter: cluster.DataCenterTwo},
+		{GRPCAddress: "127.0.0.1:9791", HTTPAddress: "127.0.0.1:9781", DataCenter: cluster.DataCenterTwo},
+		{GRPCAddress: "127.0.0.1:9792", HTTPAddress: "127.0.0.1:9782", DataCenter: cluster.DataCenterTwo},
+		{GRPCAddress: "127.0.0.1:9793", HTTPAddress: "127.0.0.1:9783", DataCenter: cluster.DataCenterTwo},
 	}); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/global.go
+++ b/global.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gubernator
 
 import (
-	"context"
 	"time"
 
 	"github.com/mailgun/holster/v4/clock"
@@ -59,104 +58,8 @@ func newGlobalManager(conf BehaviorConfig, instance *V1Instance) *globalManager 
 		instance:       instance,
 		conf:           conf,
 	}
-	gm.runAsyncHits()
 	gm.runBroadcasts()
 	return &gm
-}
-
-func (gm *globalManager) QueueHit(r *RateLimitReq) {
-	gm.asyncQueue <- r
-}
-
-func (gm *globalManager) QueueUpdate(r *RateLimitReq) {
-	gm.broadcastQueue <- r
-}
-
-// runAsyncHits collects async hit requests and queues them to
-// be sent to their owning peers.
-func (gm *globalManager) runAsyncHits() {
-	var interval = NewInterval(gm.conf.GlobalSyncWait)
-	hits := make(map[string]*RateLimitReq)
-
-	gm.wg.Until(func(done chan struct{}) bool {
-		select {
-		case r := <-gm.asyncQueue:
-			// Aggregate the hits into a single request
-			key := r.HashKey()
-			_, ok := hits[key]
-			if ok {
-				hits[key].Hits += r.Hits
-			} else {
-				hits[key] = r
-			}
-
-			// Send the hits if we reached our batch limit
-			if len(hits) == gm.conf.GlobalBatchLimit {
-				gm.sendHits(hits)
-				hits = make(map[string]*RateLimitReq)
-				return true
-			}
-
-			// If this is our first queued hit since last send
-			// queue the next interval
-			if len(hits) == 1 {
-				interval.Next()
-			}
-
-		case <-interval.C:
-			if len(hits) != 0 {
-				gm.sendHits(hits)
-				hits = make(map[string]*RateLimitReq)
-			}
-		case <-done:
-			return false
-		}
-		return true
-	})
-}
-
-// sendHits takes the hits collected by runAsyncHits and sends them to their
-// owning peers
-func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
-	type pair struct {
-		client *PeerClient
-		req    GetPeerRateLimitsReq
-	}
-	peerRequests := make(map[string]*pair)
-	start := clock.Now()
-
-	// Assign each request to a peer
-	for _, r := range hits {
-		peer, err := gm.instance.GetPeer(r.HashKey())
-		if err != nil {
-			gm.log.WithError(err).Errorf("while getting peer for hash key '%s'", r.HashKey())
-			continue
-		}
-
-		p, ok := peerRequests[peer.Info().GRPCAddress]
-		if ok {
-			p.req.Requests = append(p.req.Requests, r)
-		} else {
-			peerRequests[peer.Info().GRPCAddress] = &pair{
-				client: peer,
-				req:    GetPeerRateLimitsReq{Requests: []*RateLimitReq{r}},
-			}
-		}
-	}
-
-	// Send the rate limit requests to their respective owning peers.
-	for _, p := range peerRequests {
-		ctx, cancel := context.WithTimeout(context.Background(), gm.conf.GlobalTimeout)
-		_, err := p.client.GetPeerRateLimits(ctx, &p.req)
-		cancel()
-
-		if err != nil {
-			gm.log.WithError(err).
-				Errorf("error sending global hits to '%s'", p.client.Info().GRPCAddress)
-			continue
-		}
-	}
-	gm.asyncMetrics.Observe(time.Since(start).Seconds())
 }
 
 // runBroadcasts collects status changes for global rate limits and broadcasts the changes to each peer in the cluster.
@@ -196,7 +99,7 @@ func (gm *globalManager) runBroadcasts() {
 
 // broadcastPeers broadcasts global rate limit statuses to all other peers
 func (gm *globalManager) broadcastPeers(updates map[string]*RateLimitReq) {
-	var req UpdatePeerGlobalsReq
+	//var req UpdatePeerGlobalsReq
 	start := clock.Now()
 
 	for _, r := range updates {
@@ -225,19 +128,11 @@ func (gm *globalManager) broadcastPeers(updates map[string]*RateLimitReq) {
 		if peer.Info().IsOwner {
 			continue
 		}
+	// TODO: Marshall updates into buffer
 
-		ctx, cancel := context.WithTimeout(context.Background(), gm.conf.GlobalTimeout)
-		_, err := peer.UpdatePeerGlobals(ctx, &req)
-		cancel()
+	// TODO: Compress buffer
 
-		if err != nil {
-			// Skip peers that are not in a ready state
-			if !IsNotReady(err) {
-				gm.log.WithError(err).Errorf("while broadcasting global updates to '%s'", peer.Info().GRPCAddress)
-			}
-			continue
-		}
-	}
+	// TODO: Send to peers
 
 	gm.broadcastMetrics.Observe(time.Since(start).Seconds())
 }

--- a/proto/peers.proto
+++ b/proto/peers.proto
@@ -31,6 +31,9 @@ service PeersV1 {
 
     // Used by peers send global rate limit updates to other peers
     rpc UpdatePeerGlobals (UpdatePeerGlobalsReq) returns (UpdatePeerGlobalsResp) {}
+
+    // Used by multi-region manager to send rate limits to other regions
+    rpc UpdateRateLimits (UpdateRateLimitsReq) returns (UpdateRateLimitsResp) {}
 }
 
 message GetPeerRateLimitsReq {
@@ -54,4 +57,12 @@ message UpdatePeerGlobal {
     RateLimitResp status = 2;
     Algorithm algorithm = 3;
 }
+
 message UpdatePeerGlobalsResp {}
+
+message UpdateRateLimitsReq {
+    // Must specify at least one RateLimit
+    repeated RateLimitReq rate_limits = 1;
+}
+
+message UpdateRateLimitsResp {}


### PR DESCRIPTION
## Purpose
Given multiple data centers Gubernator nodes should replicate Ratelimit updates to their peers in other regions. We determine which peers get the updates by consulting the regional peer picker. The difficulty is in coordinating and updating the list of peers in each region. Each region should keep track of their peers and then notify the other regions when the peer list changes. 

This might be simplified by having a single coordinating node in each region who is responsible for distributing the ratelimit updates to the appropriate peers. The coordinator could be any node in the region, choosing the node could be resolved by either a DNS entry or round robin via the regions service mesh. 