### PR TITLE
WIP: Testing channel based cache and algo handler pool

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -36,6 +36,8 @@ type Cache interface {
 	Each() chan *CacheItem
 	Remove(key interface{})
 
+	New() Cache
+
 	// If the cache is exclusive, this will control access to the cache
 	Unlock()
 	Lock()
@@ -90,6 +92,11 @@ func NewLRUCache(maxSize int) *LRUCache {
 		accessMetric: prometheus.NewDesc("gubernator_cache_access_count",
 			"Cache access counts.", []string{"type"}, nil),
 	}
+}
+
+// New returns a new instance of the cache with the same config as the original
+func (c *LRUCache) New() Cache {
+	return NewLRUCache(c.cacheSize)
 }
 
 func (c *LRUCache) Lock() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mailgun/gubernator/v2
 go 1.14
 
 require (
+	github.com/OneOfOne/xxhash v1.2.8
 	github.com/davecgh/go-spew v1.1.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/hashicorp/memberlist v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
+github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ahmetb/go-linq v3.0.0+incompatible h1:qQkjjOXKrKOTy83X8OpRmnKflXKQIL/mC/gMVVDMhOA=

--- a/handler_pool.go
+++ b/handler_pool.go
@@ -1,0 +1,113 @@
+package gubernator
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/OneOfOne/xxhash"
+	"github.com/mailgun/holster/v4/errors"
+)
+
+type HandlerPool struct {
+	keys []chanInfo
+}
+
+type chanInfo struct {
+	hash uint64
+	ch   *chan request
+}
+
+// spawnHandlerPool create a new pool of threads to handle incoming rate limit requests
+func spawnHandlerPool(conf Config, count int) *HandlerPool {
+	cp := &HandlerPool{}
+
+	for i := 0; i < count; i++ {
+		// I picked an arbitrary 1k queue size, change later?
+		ch := make(chan request, 1_000)
+		// TODO: Move this into it's own function
+		go func() {
+			// TODO: Doing this causes the very first instance of cache to be thrown away....
+			//   Perhaps conf.Cache could be a function that returns a new instance as configured according to the user.
+			//   Or we introduce a new thing in the config `conf.InstantiateCache()` ?
+			localCache := conf.Cache.New()
+			for {
+				select {
+				case r, ok := <-ch:
+					if !ok {
+						//fmt.Printf("[GO] Not ok\n")
+						return
+					}
+					var rl *RateLimitResp
+					var err error
+
+					switch r.request.Algorithm {
+					case Algorithm_TOKEN_BUCKET:
+						//fmt.Printf("[GO] Token Bucket\n")
+						rl, err = tokenBucket(conf.Store, localCache, r.request)
+					case Algorithm_LEAKY_BUCKET:
+						rl, err = leakyBucket(conf.Store, localCache, r.request)
+					default:
+						err = errors.Errorf("invalid rate limit algorithm '%d'", r.request.Algorithm)
+					}
+					//fmt.Printf("[GO] Send Resp\n")
+					r.resp <- &response{
+						rl:  rl,
+						err: err,
+					}
+				}
+			}
+		}()
+		cp.add(&ch)
+	}
+	return cp
+}
+
+func (cp *HandlerPool) Handle(r *RateLimitReq) (*RateLimitResp, error) {
+	ch := cp.get(r.UniqueKey)
+	req := request{
+		resp:    make(chan *response, 1),
+		request: r,
+	}
+
+	//fmt.Printf("Send Req\n")
+	// Send the request to the thread pool
+	*ch <- req
+
+	// TODO: Not sure if we should check a context here, if one of the go
+	//  routines doesn't return, that is more likely a code error than a runtime error.
+	resp := <-req.resp
+	//fmt.Printf("Got Resp\n")
+	return resp.rl, resp.err
+}
+
+// Close closed all handlers in the pool. User should only be called once we can guarantee
+// no more requests to HandlerPool will be made.
+func (cp *HandlerPool) Close() {
+	// TODO: Close all the go routine channels, which should signal the routines to close
+}
+
+// add a channel tied to a go routine to the pool
+func (cp *HandlerPool) add(ch *chan request) {
+	key := fmt.Sprintf("%x", ch)
+	hash := xxhash.ChecksumString64S(key, 0)
+	cp.keys = append(cp.keys, chanInfo{
+		hash: hash,
+		ch:   ch,
+	})
+	sort.Slice(cp.keys, func(i, j int) bool { return cp.keys[i].hash < cp.keys[j].hash })
+}
+
+// get returns the  that key is assigned too
+func (cp *HandlerPool) get(key string) *chan request {
+	hash := xxhash.ChecksumString64S(key, 0)
+
+	// Binary search for appropriate channel
+	idx := sort.Search(len(cp.keys), func(i int) bool { return cp.keys[i].hash >= hash })
+
+	// Means we have cycled back to the first
+	if idx == len(cp.keys) {
+		idx = 0
+	}
+	//fmt.Printf("Channel: %d\n", idx)
+	return cp.keys[idx].ch
+}


### PR DESCRIPTION
This creates a pool of rate limit request handlers, one go routine for each CPU on the current box. The old implementation provided single threaded access to the cache which might cause lock contentions as the kernel mutex is not completely fair. This hashes the request UniqueID to determine which CPU/Cache will handle the request.

```
// Previous Single threaded implementation
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching-12               10000        139095 ns/op

// After implementing handler pool based solution
BenchmarkServer_GetPeerRateLimitNoBatching/GetPeerRateLimitNoBatching-12               10000        101584 ns/op
```

## TODO
* Handle global and global updates in the HandlerPool go routine.
* Improve how cache is created
* Implement clean shutdown of HandlerPool