### PR TITLE
Fix: Include s.conf.Behaviors in Config for NewV1Instance

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -115,6 +115,7 @@ func (s *Daemon) Start(ctx context.Context) error {
 		GRPCServers: s.grpcSrvs,
 		Logger:      s.log,
 		Cache:       cache,
+		Behaviors:   s.conf.Behaviors,
 	})
 	if err != nil {
 		return errors.Wrap(err, "while creating new gubernator instance")


### PR DESCRIPTION
#### Why I made this change

I tracked down an issue in our system to `BatchTimeout` being left at its default value of 500 ms. I redeployed gubernator with `GUBER_BATCH_TIMEOUT` set to `1s`. Upon startup I see the config in logs which includes the following: `BatchTimeout: (time.Duration) 1s` so I presume I set the envvar properly.

Howver, the test I usually run (which discovered the root cause as `BatchTimeout` being 500 ms) still yielded the same result: some requests would return an error whose cause was content deadline expiration even though the entire request only took ~558 ms for example. I believe the cause is that `Behaviors` is not set in the `Config` passed to `NewV1Instance`. I assume this is unintentional.


Please let me know if I'm wrong here or if I need to change anything else.