### PR TITLE
Fix recursion causing stack overflow in `tokenBucket()`.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,7 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/mock_store_test.go
+++ b/mock_store_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018-2022 Mailgun Technologies Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gubernator_test
+
+// Mock implementation of Store.
+
+import (
+	guber "github.com/mailgun/gubernator/v2"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockStore2 struct {
+	mock.Mock
+}
+
+var _ guber.Store = &MockStore2{}
+
+func (m *MockStore2) OnChange(r *guber.RateLimitReq, item *guber.CacheItem) {
+	m.Called(r, item)
+}
+
+func (m *MockStore2) Get(r *guber.RateLimitReq) (*guber.CacheItem, bool) {
+	args := m.Called(r)
+	var retval *guber.CacheItem
+	if retval2, ok := args.Get(0).(*guber.CacheItem); ok {
+		retval = retval2
+	}
+	return retval, args.Bool(1)
+}
+
+func (m *MockStore2) Remove(key string) {
+	m.Called(key)
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2019 Mailgun Technologies Inc
+Copyright 2018-2022 Mailgun Technologies Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"github.com/mailgun/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -35,9 +36,9 @@ type v1Server struct {
 	srv      *gubernator.V1Instance
 }
 
-func (s *v1Server) Close() {
+func (s *v1Server) Close() error {
 	s.conf.GRPCServers[0].GracefulStop()
-	s.srv.Close()
+	return s.srv.Close()
 }
 
 // Start a single instance of V1Server with the provided config and listening address.
@@ -107,7 +108,8 @@ func TestLoader(t *testing.T) {
 	require.Equal(t, 1, len(resp.Responses))
 	require.Equal(t, "", resp.Responses[0].Error)
 
-	srv.Close()
+	err = srv.Close()
+	require.NoError(t, err, "Error in srv.Close")
 
 	// Loader.Save() should been called during gubernator shutdown
 	assert.Equal(t, 1, loader.Called["Load()"])
@@ -123,166 +125,405 @@ func TestLoader(t *testing.T) {
 }
 
 func TestStore(t *testing.T) {
-	tests := []struct {
-		name            string
-		firstRemaining  int64
-		firstStatus     gubernator.Status
-		secondRemaining int64
-		secondStatus    gubernator.Status
-		algorithm       gubernator.Algorithm
-		switchAlgorithm gubernator.Algorithm
-		testCase        func(*gubernator.RateLimitReq, *gubernator.MockStore)
-	}{
-		{
-			name:            "Given there are no token bucket limits in the store",
-			firstRemaining:  int64(9),
-			firstStatus:     gubernator.Status_UNDER_LIMIT,
-			secondRemaining: int64(8),
-			secondStatus:    gubernator.Status_UNDER_LIMIT,
-			algorithm:       gubernator.Algorithm_TOKEN_BUCKET,
-			switchAlgorithm: gubernator.Algorithm_LEAKY_BUCKET,
-			testCase:        func(req *gubernator.RateLimitReq, store *gubernator.MockStore) {},
-		},
-		{
-			name:            "Given the store contains a token bucket rate limit not in the guber cache",
-			firstRemaining:  int64(0),
-			firstStatus:     gubernator.Status_UNDER_LIMIT,
-			secondRemaining: int64(0),
-			secondStatus:    gubernator.Status_OVER_LIMIT,
-			algorithm:       gubernator.Algorithm_TOKEN_BUCKET,
-			switchAlgorithm: gubernator.Algorithm_LEAKY_BUCKET,
-			testCase: func(req *gubernator.RateLimitReq, store *gubernator.MockStore) {
-				now := gubernator.MillisecondNow()
-				// Expire 1 second from now
-				expire := now + gubernator.Second
-				store.CacheItems[req.HashKey()] = &gubernator.CacheItem{
-					Algorithm: gubernator.Algorithm_TOKEN_BUCKET,
-					ExpireAt:  expire,
-					Key:       req.HashKey(),
-					Value: &gubernator.TokenBucketItem{
-						Limit:     req.Limit,
-						Duration:  req.Duration,
-						CreatedAt: now,
-						Remaining: 1,
-					},
-				}
-			},
-		},
-		{
-			name:            "Given there are no leaky bucket limits in the store",
-			firstRemaining:  int64(9),
-			firstStatus:     gubernator.Status_UNDER_LIMIT,
-			secondRemaining: int64(8),
-			secondStatus:    gubernator.Status_UNDER_LIMIT,
-			algorithm:       gubernator.Algorithm_LEAKY_BUCKET,
-			switchAlgorithm: gubernator.Algorithm_TOKEN_BUCKET,
-			testCase:        func(req *gubernator.RateLimitReq, store *gubernator.MockStore) {},
-		},
-		{
-			name:            "Given the store contains a leaky bucket rate limit not in the guber cache",
-			firstRemaining:  int64(0),
-			firstStatus:     gubernator.Status_UNDER_LIMIT,
-			secondRemaining: int64(0),
-			secondStatus:    gubernator.Status_OVER_LIMIT,
-			algorithm:       gubernator.Algorithm_LEAKY_BUCKET,
-			switchAlgorithm: gubernator.Algorithm_TOKEN_BUCKET,
-			testCase: func(req *gubernator.RateLimitReq, store *gubernator.MockStore) {
-				// Expire 1 second from now
-				expire := gubernator.MillisecondNow() + gubernator.Second
-				store.CacheItems[req.HashKey()] = &gubernator.CacheItem{
-					Algorithm: gubernator.Algorithm_LEAKY_BUCKET,
-					ExpireAt:  expire,
-					Key:       req.HashKey(),
-					Value: &gubernator.LeakyBucketItem{
-						UpdatedAt: gubernator.MillisecondNow(),
-						Duration:  req.Duration,
-						Limit:     req.Limit,
-						Remaining: 1,
-						Burst:     req.Limit,
-					},
-				}
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := gubernator.NewMockStore()
+	setup := func() (*MockStore2, *v1Server, gubernator.V1Client) {
+		store := &MockStore2{}
 
-			srv := newV1Server(t, "", gubernator.Config{
-				Behaviors: gubernator.BehaviorConfig{
-					GlobalSyncWait: clock.Millisecond * 50, // Suitable for testing but not production
-					GlobalTimeout:  clock.Second,
-				},
-				Store: store,
+		srv := newV1Server(t, "", gubernator.Config{
+			Behaviors: gubernator.BehaviorConfig{
+				GlobalSyncWait: clock.Millisecond * 50, // Suitable for testing but not production
+				GlobalTimeout:  clock.Second,
+			},
+			Store: store,
+		})
+
+		client, err := gubernator.DialV1Server(srv.listener.Addr().String(), nil)
+		require.NoError(t, err)
+
+		return store, srv, client
+	}
+
+	tearDown := func(srv *v1Server) {
+		err := srv.Close()
+		require.NoError(t, err)
+	}
+
+	// Create a mock argument matcher for a request by name/key.
+	matchReq := func(req *gubernator.RateLimitReq) interface{} {
+		return mock.MatchedBy(func(req2 *gubernator.RateLimitReq) bool {
+			return req2.Name == req.Name &&
+				req2.UniqueKey == req.UniqueKey
+		})
+	}
+
+	// Create a mock argument matcher for CacheItem input.
+	// Verify item matches expected algorithm, limit, and duration.
+	matchItem := func(algorithm gubernator.Algorithm, req *gubernator.RateLimitReq) interface{} {
+		switch algorithm {
+		case gubernator.Algorithm_TOKEN_BUCKET:
+			return mock.MatchedBy(func(item *gubernator.CacheItem) bool {
+				titem, ok := item.Value.(*gubernator.TokenBucketItem)
+				if !ok {
+					return false
+				}
+
+				return item.Algorithm == algorithm &&
+					item.Key == req.HashKey() &&
+					titem.Limit == req.Limit &&
+					titem.Duration == req.Duration
 			})
 
-			// No calls to store
-			assert.Equal(t, 0, store.Called["OnChange()"])
-			assert.Equal(t, 0, store.Called["Get()"])
+		case gubernator.Algorithm_LEAKY_BUCKET:
+			return mock.MatchedBy(func(item *gubernator.CacheItem) bool {
+				litem, ok := item.Value.(*gubernator.LeakyBucketItem)
+				if !ok {
+					return false
+				}
 
-			client, err := gubernator.DialV1Server(srv.listener.Addr().String(), nil)
-			assert.Nil(t, err)
+				return item.Algorithm == algorithm &&
+					item.Key == req.HashKey() &&
+					litem.Limit == req.Limit &&
+					litem.Duration == req.Duration
+			})
 
-			req := gubernator.RateLimitReq{
-				Name:      "test_over_limit",
-				UniqueKey: "account:1234",
-				Algorithm: tt.algorithm,
-				Duration:  gubernator.Second,
-				Limit:     10,
-				Hits:      1,
+		default:
+			assert.Fail(t, "Unknown algorithm")
+			return nil
+		}
+	}
+
+	// Create a bucket item matching the request.
+	createBucketItem := func(req *gubernator.RateLimitReq) interface{} {
+		switch req.Algorithm {
+		case gubernator.Algorithm_TOKEN_BUCKET:
+			return &gubernator.TokenBucketItem{
+				Limit:     req.Limit,
+				Duration:  req.Duration,
+				CreatedAt: gubernator.MillisecondNow(),
+				Remaining: req.Limit,
 			}
 
-			tt.testCase(&req, store)
+		case gubernator.Algorithm_LEAKY_BUCKET:
+			return &gubernator.LeakyBucketItem{
+				Limit:     req.Limit,
+				Duration:  req.Duration,
+				UpdatedAt: gubernator.MillisecondNow(),
+			}
 
-			// This request for the rate limit should ask the store via Get() and then
-			// tell the store about the change to the rate limit by calling OnChange()
-			resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
-				Requests: []*gubernator.RateLimitReq{&req},
+		default:
+			assert.Fail(t, "Unknown algorithm")
+			return nil
+		}
+	}
+
+	testCases := []struct {
+		Name      string
+		Algorithm gubernator.Algorithm
+	}{
+		{"Token bucket", gubernator.Algorithm_TOKEN_BUCKET},
+		{"Leaky bucket", gubernator.Algorithm_LEAKY_BUCKET},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Run("First rate check pulls from store", func(t *testing.T) {
+				store, srv, client := setup()
+				defer tearDown(srv)
+
+				req := &gubernator.RateLimitReq{
+					Name:      "test_over_limit",
+					UniqueKey: "account:1234",
+					Algorithm: testCase.Algorithm,
+					Duration:  gubernator.Second,
+					Limit:     10,
+					Hits:      1,
+				}
+
+				// Setup mocks.
+				store.On("Get", matchReq(req)).Once().Return(&gubernator.CacheItem{}, false)
+				store.On("OnChange", matchReq(req), matchItem(testCase.Algorithm, req)).Once()
+
+				// Call code.
+				resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+					Requests: []*gubernator.RateLimitReq{req},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Responses, 1)
+				assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+				assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+				store.AssertExpectations(t)
+
+				t.Run("Second rate check pulls from cache", func(t *testing.T) {
+					// Setup mocks.
+					store.On("OnChange", matchReq(req), matchItem(testCase.Algorithm, req)).Once()
+
+					// Call code.
+					resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+						Requests: []*gubernator.RateLimitReq{req},
+					})
+					require.NoError(t, err)
+					require.NotNil(t, resp)
+					assert.Len(t, resp.Responses, 1)
+					assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+					assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+					store.AssertExpectations(t)
+				})
 			})
-			require.Nil(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, 1, len(resp.Responses))
-			require.Equal(t, "", resp.Responses[0].Error)
-			assert.Equal(t, tt.firstRemaining, resp.Responses[0].Remaining)
-			assert.Equal(t, int64(10), resp.Responses[0].Limit)
-			assert.Equal(t, tt.firstStatus, resp.Responses[0].Status)
 
-			// Should have called OnChange() and Get()
-			assert.Equal(t, 1, store.Called["OnChange()"])
-			assert.Equal(t, 1, store.Called["Get()"])
+			t.Run("Found in store after cache miss", func(t *testing.T) {
+				store, srv, client := setup()
+				defer tearDown(srv)
 
-			// Should have updated the store
-			assert.Equal(t, tt.firstRemaining, getRemaining(store.CacheItems[req.HashKey()]))
+				req := &gubernator.RateLimitReq{
+					Name:      "test_over_limit",
+					UniqueKey: "account:1234",
+					Algorithm: testCase.Algorithm,
+					Duration:  gubernator.Second,
+					Limit:     10,
+					Hits:      1,
+				}
 
-			// Next call should not call `Get()` but only `OnChange()`
-			resp, err = client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
-				Requests: []*gubernator.RateLimitReq{&req},
+				// Setup mocks.
+				now := gubernator.MillisecondNow()
+				expire := now + req.Duration
+				storedItem := &gubernator.CacheItem{
+					Algorithm: req.Algorithm,
+					ExpireAt:  expire,
+					Key:       req.HashKey(),
+					Value:     createBucketItem(req),
+				}
+
+				store.On("Get", matchReq(req)).Once().Return(storedItem, true)
+				store.On("OnChange", matchReq(req), matchItem(testCase.Algorithm, req)).Once()
+
+				// Call code.
+				resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+					Requests: []*gubernator.RateLimitReq{req},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Responses, 1)
+				assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+				assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+				store.AssertExpectations(t)
 			})
-			require.Nil(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tt.secondRemaining, resp.Responses[0].Remaining)
-			assert.Equal(t, int64(10), resp.Responses[0].Limit)
-			assert.Equal(t, tt.secondStatus, resp.Responses[0].Status)
 
-			// Should have called OnChange() not Get() since rate limit is in the cache
-			assert.Equal(t, 2, store.Called["OnChange()"])
-			assert.Equal(t, 1, store.Called["Get()"])
+			t.Run("Algorithm changed", func(t *testing.T) {
+				// Removes stored item, then creates new.
+				store, srv, client := setup()
+				defer tearDown(srv)
 
-			// Should have updated the store
-			assert.Equal(t, tt.secondRemaining, getRemaining(store.CacheItems[req.HashKey()]))
+				req := &gubernator.RateLimitReq{
+					Name:      "test_over_limit",
+					UniqueKey: "account:1234",
+					Algorithm: testCase.Algorithm,
+					Duration:  gubernator.Second,
+					Limit:     10,
+					Hits:      1,
+				}
 
-			// Should have called `Remove()` when algorithm changed
-			req.Algorithm = tt.switchAlgorithm
-			resp, err = client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
-				Requests: []*gubernator.RateLimitReq{&req},
+				// Setup mocks.
+				now := gubernator.MillisecondNow()
+				expire := now + req.Duration
+				storedItem := &gubernator.CacheItem{
+					Algorithm: req.Algorithm,
+					ExpireAt:  expire,
+					Key:       req.HashKey(),
+					Value:     &struct{}{},
+				}
+
+				store.On("Get", matchReq(req)).Once().Return(storedItem, true)
+				store.On("Remove", req.HashKey()).Once()
+				store.On("OnChange", matchReq(req), matchItem(testCase.Algorithm, req)).Once()
+
+				// Call code.
+				resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+					Requests: []*gubernator.RateLimitReq{req},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Responses, 1)
+				assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+				assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+				store.AssertExpectations(t)
 			})
-			require.Nil(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, 1, store.Called["Remove()"])
-			assert.Equal(t, 3, store.Called["OnChange()"])
-			assert.Equal(t, 2, store.Called["Get()"])
 
-			assert.Equal(t, tt.switchAlgorithm, store.CacheItems[req.HashKey()].Algorithm)
+			// Duration changed logic implemented only in token bucket.
+			// TODO: Implement in leaky bucket.
+			if testCase.Algorithm == gubernator.Algorithm_TOKEN_BUCKET {
+				t.Run("Duration changed", func(t *testing.T) {
+					// Updates expiration timestamp in store.
+					store, srv, client := setup()
+					defer tearDown(srv)
+
+					oldDuration := int64(5000)
+					newDuration := int64(8000)
+					req := &gubernator.RateLimitReq{
+						Name:      "test_over_limit",
+						UniqueKey: "account:1234",
+						Algorithm: testCase.Algorithm,
+						Duration:  newDuration,
+						Limit:     10,
+						Hits:      1,
+					}
+
+					// Setup mocks.
+					now := gubernator.MillisecondNow()
+					oldExpire := now + oldDuration
+					bucketItem := createBucketItem(req)
+					switch req.Algorithm {
+					case gubernator.Algorithm_TOKEN_BUCKET:
+						bucketItem.(*gubernator.TokenBucketItem).Duration = oldDuration
+
+					case gubernator.Algorithm_LEAKY_BUCKET:
+						bucketItem.(*gubernator.LeakyBucketItem).Duration = oldDuration
+					}
+					storedItem := &gubernator.CacheItem{
+						Algorithm: req.Algorithm,
+						ExpireAt:  oldExpire,
+						Key:       req.HashKey(),
+						Value:     bucketItem,
+					}
+
+					store.On("Get", matchReq(req)).Once().Return(storedItem, true)
+
+					store.On("OnChange",
+						matchReq(req),
+						mock.MatchedBy(func(item *gubernator.CacheItem) bool {
+							switch req.Algorithm {
+							case gubernator.Algorithm_TOKEN_BUCKET:
+								titem, ok := item.Value.(*gubernator.TokenBucketItem)
+								if !ok {
+									return false
+								}
+
+								return item.Algorithm == req.Algorithm &&
+									item.Key == req.HashKey() &&
+									item.ExpireAt == titem.CreatedAt+newDuration &&
+									titem.Limit == req.Limit &&
+									titem.Duration == req.Duration
+
+							case gubernator.Algorithm_LEAKY_BUCKET:
+								litem, ok := item.Value.(*gubernator.LeakyBucketItem)
+								if !ok {
+									return false
+								}
+
+								return item.Algorithm == req.Algorithm &&
+									item.Key == req.HashKey() &&
+									item.ExpireAt == litem.UpdatedAt+newDuration &&
+									litem.Limit == req.Limit &&
+									litem.Duration == req.Duration
+
+							default:
+								assert.Fail(t, "Unknown algorithm")
+								return false
+							}
+						}),
+					).
+						Once()
+
+					// Call code.
+					resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+						Requests: []*gubernator.RateLimitReq{req},
+					})
+					require.NoError(t, err)
+					require.NotNil(t, resp)
+					assert.Len(t, resp.Responses, 1)
+					assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+					assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+					store.AssertExpectations(t)
+				})
+
+				t.Run("Duration changed and immediately expired", func(t *testing.T) {
+					// Occurs when new duration is shorter and is immediately expired
+					// because CreatedAt + NewDuration < Now.
+					// Stores new item with renewed expiration and resets remaining.
+					store, srv, client := setup()
+					defer tearDown(srv)
+
+					oldDuration := int64(500000)
+					newDuration := int64(8000)
+					req := &gubernator.RateLimitReq{
+						Name:      "test_over_limit",
+						UniqueKey: "account:1234",
+						Algorithm: testCase.Algorithm,
+						Duration:  newDuration,
+						Limit:     10,
+						Hits:      1,
+					}
+
+					// Setup mocks.
+					now := gubernator.MillisecondNow()
+					longTimeAgo := now - 100000
+					oldExpire := longTimeAgo + oldDuration
+					bucketItem := createBucketItem(req)
+					switch req.Algorithm {
+					case gubernator.Algorithm_TOKEN_BUCKET:
+						bucketItem.(*gubernator.TokenBucketItem).Duration = oldDuration
+						bucketItem.(*gubernator.TokenBucketItem).CreatedAt = longTimeAgo
+
+					case gubernator.Algorithm_LEAKY_BUCKET:
+						bucketItem.(*gubernator.LeakyBucketItem).Duration = oldDuration
+						bucketItem.(*gubernator.LeakyBucketItem).UpdatedAt = longTimeAgo
+					}
+					storedItem := &gubernator.CacheItem{
+						Algorithm: req.Algorithm,
+						ExpireAt:  oldExpire,
+						Key:       req.HashKey(),
+						Value:     bucketItem,
+					}
+
+					store.On("Get", matchReq(req)).Once().Return(storedItem, true)
+
+					store.On("OnChange",
+						matchReq(req),
+						mock.MatchedBy(func(item *gubernator.CacheItem) bool {
+							switch req.Algorithm {
+							case gubernator.Algorithm_TOKEN_BUCKET:
+								titem, ok := item.Value.(*gubernator.TokenBucketItem)
+								if !ok {
+									return false
+								}
+
+								return item.Algorithm == req.Algorithm &&
+									item.Key == req.HashKey() &&
+									item.ExpireAt == titem.CreatedAt+newDuration &&
+									titem.Limit == req.Limit &&
+									titem.Duration == req.Duration
+
+							case gubernator.Algorithm_LEAKY_BUCKET:
+								litem, ok := item.Value.(*gubernator.LeakyBucketItem)
+								if !ok {
+									return false
+								}
+
+								return item.Algorithm == req.Algorithm &&
+									item.Key == req.HashKey() &&
+									item.ExpireAt == litem.UpdatedAt+newDuration &&
+									litem.Limit == req.Limit &&
+									litem.Duration == req.Duration
+
+							default:
+								assert.Fail(t, "Unknown algorithm")
+								return false
+							}
+						}),
+					).
+						Once()
+
+					// Call code.
+					resp, err := client.GetRateLimits(context.Background(), &gubernator.GetRateLimitsReq{
+						Requests: []*gubernator.RateLimitReq{req},
+					})
+					require.NoError(t, err)
+					require.NotNil(t, resp)
+					assert.Len(t, resp.Responses, 1)
+					assert.Equal(t, req.Limit, resp.Responses[0].Limit)
+					assert.Equal(t, gubernator.Status_UNDER_LIMIT, resp.Responses[0].Status)
+					store.AssertExpectations(t)
+				})
+			}
 		})
 	}
 }

--- a/store_test.go
+++ b/store_test.go
@@ -348,6 +348,8 @@ func TestStore(t *testing.T) {
 				store.AssertExpectations(t)
 			})
 
+			// Discovered a bug where changing the duration of rate limit caused infinite recursion.
+			// This test exercises that condition.  See PR #123.
 			// Duration changed logic implemented only in token bucket.
 			// TODO: Implement in leaky bucket.
 			if testCase.Algorithm == gubernator.Algorithm_TOKEN_BUCKET {


### PR DESCRIPTION
Fixed: if a limit duration changes and becomes expired, a stack overflow condition occurs.

Refactor unit tests using stretchr mocking tools.