### PR TITLE
Allow multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM --platform=$BUILDPLATFORM golang:1.17 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
+# https://github.com/docker/buildx/issues/510#issuecomment-768432329
+ENV BUILDPLATFORM=${BUILDPLATFORM:-linux/amd64}
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
 WORKDIR /go/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build image
-FROM golang:1.17 as build
+FROM --platform=$BUILDPLATFORM golang:1.17 as build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 WORKDIR /go/src
 
@@ -14,7 +16,7 @@ ADD . /go/src
 ARG VERSION
 
 # Build the server inside the container
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
+RUN CGO_ENABLED=0 GOOS=${TARGETPLATFORM%/*} GOARCH=${TARGETPLATFORM#*/} go build -a -installsuffix cgo \
     -ldflags "-w -s -X main.Version=$VERSION" -o /gubernator /go/src/cmd/gubernator/main.go
 
 # Create our deploy image

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -2,6 +2,9 @@
 FROM --platform=$BUILDPLATFORM golang:1.17 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
+# https://github.com/docker/buildx/issues/510#issuecomment-768432329
+ENV BUILDPLATFORM=${BUILDPLATFORM:-linux/amd64}
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 
 WORKDIR /go/src
 

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,5 +1,7 @@
 # Build image
-FROM golang:1.17 as build
+FROM --platform=$BUILDPLATFORM golang:1.17 as build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 WORKDIR /go/src
 
@@ -14,7 +16,7 @@ ADD . /go/src
 ARG VERSION
 
 # Build the server inside the container
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
+RUN CGO_ENABLED=0 GOOS=${TARGETPLATFORM%/*} GOARCH=${TARGETPLATFORM#*/} go build -a -installsuffix cgo \
     -ldflags "-w -s -X main.Version=$VERSION" -o /gubernator-cli /go/src/cmd/gubernator-cli/main.go
 
 # Create our deploy image


### PR DESCRIPTION
Today we only build amd64 images for gubernator, and that's silly when go is so good at providing cross-architecture builds.  Lets borrow a page from [the book](https://docs.docker.com/buildx/working-with-buildx/), and use _host-native_ build images (to ignore all of the painful QEMU and golang issues), with a target architecture that can be specified by docker at build time via the `--platform` flag.

This permits us to, for example, simply
```bash
docker buildx build --platform linux/arm64,linux/amd64 -t gubernator:latest .
```

And sing, and dance, and tra la la.  In fact...  check out https://hub.docker.com/repository/docker/jontg/gubernator where I published the results of ☝️