### PR TITLE
Pin Go to 1.17.9, always pull the base image

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -38,7 +38,8 @@ jobs:
             ghcr.io/mailgun/gubernator:latest
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
-          push: true           
+          pull: true
+          push: true
       
       # Commit the updated 'version' file
       - name: Commit changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.17 as build
+FROM --platform=$BUILDPLATFORM golang:1.17.9 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 # https://github.com/docker/buildx/issues/510#issuecomment-768432329

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.17 as build
+FROM --platform=$BUILDPLATFORM golang:1.17.9 as build
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 # https://github.com/docker/buildx/issues/510#issuecomment-768432329


### PR DESCRIPTION
It's generally recommended to pin images to a specific patch, rather than a minor version. That way updates that address Go CVEs will be more intentional, rather than just a rebuild of the latest release.

Also enabled `pull` mode to ensure that it's always using the freshest base images.