### PR TITLE
helm chart add image pull secrets

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -28,11 +28,16 @@ spec:
       {{ else }}
       serviceAccountName: {{ .Values.gubernator.serviceAccount.name }}
       {{- end}}
+      {{- with $.Values.gubernator.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gubernator
           env:
           {{- include "gubernator.env" . | nindent 10 }}
           image: {{ .Values.gubernator.image.repository }}:{{ .Values.gubernator.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.gubernator.image.pullPolicy }}
           imagePullPolicy: {{ .Values.gubernator.image.pullPolicy }}
           ports:
             - name: grpc

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           {{- include "gubernator.env" . | nindent 10 }}
           image: {{ .Values.gubernator.image.repository }}:{{ .Values.gubernator.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.gubernator.image.pullPolicy }}
-          imagePullPolicy: {{ .Values.gubernator.image.pullPolicy }}
           ports:
             - name: grpc
               containerPort: {{ include "gubernator.grpc.port" .  }}


### PR DESCRIPTION
Using an internal image hub to fullfil requirement like legal (consisitence build, virus scan, etc.) which is common practice in companies.
The original chart already specified repo and pull policy but missing "pull secret" which required by internal/private repo.

This PR set up the [image pull secret](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) for helm chart, here is an example:
```
  image:
    repository: example.com/internal/gubernator
    pullPolicy: IfNotPresent
    pullSecrets:
      - name: example-internal-secret
```