### PR TITLE
Publish multi-arch images

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -31,13 +31,14 @@ jobs:
           password: ${{ github.token }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           tags: |
             ghcr.io/mailgun/gubernator:${{ github.event.release.tag_name }}
             ghcr.io/mailgun/gubernator:latest
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
+          platforms: linux/amd64,linux/arm64
           push: true           
       
       # Commit the updated 'version' file


### PR DESCRIPTION
We merged https://github.com/mailgun/gubernator/pull/132 a few months ago, but looks like without augmenting the actual publish step, we don't... actually publish.