### PR TITLE
Add support for pre-1.23 Kubernetes versions

### DIFF
--- a/charts/gubernator/templates/hpa.yaml
+++ b/charts/gubernator/templates/hpa.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gubernator.fullname" . }}

--- a/charts/gubernator/templates/hpa.yaml
+++ b/charts/gubernator/templates/hpa.yaml
@@ -1,7 +1,7 @@
 {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 {{- end }}
 kind: HorizontalPodAutoscaler
 metadata:


### PR DESCRIPTION
Oops, `helm` seem a bit overly eager about making people update the `apiVersion`s. I didn't realize it required 1.23 :)

With this fix, it should work with all the releases supported since July 2019.