### PR TITLE
fix #156, negative hits when remaining 0

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -176,7 +176,7 @@ func tokenBucket(ctx context.Context, s Store, c Cache, r *RateLimitReq) (resp *
 		}
 
 		// If we are already at the limit.
-		if rl.Remaining == 0 {
+		if rl.Remaining == 0 && r.Hits > 0 {
 			span.AddEvent("Already over the limit")
 			overLimitCounter.Add(1)
 			rl.Status = Status_OVER_LIMIT
@@ -414,7 +414,7 @@ func leakyBucket(ctx context.Context, s Store, c Cache, r *RateLimitReq) (resp *
 		}
 
 		// If we are already at the limit
-		if int64(b.Remaining) == 0 {
+		if int64(b.Remaining) == 0 && r.Hits > 0 {
 			overLimitCounter.Add(1)
 			rl.Status = Status_OVER_LIMIT
 			return rl, nil

--- a/functional_test.go
+++ b/functional_test.go
@@ -341,8 +341,8 @@ func TestTokenBucketNegativeHits(t *testing.T) {
 			resp, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
 				Requests: []*guber.RateLimitReq{
 					{
-						Name:      "test_token_bucket",
-						UniqueKey: "account:1234",
+						Name:      "test_token_bucket_negative",
+						UniqueKey: "account:12345",
 						Algorithm: guber.Algorithm_TOKEN_BUCKET,
 						Duration:  guber.Millisecond * 5,
 						Limit:     2,
@@ -711,8 +711,8 @@ func TestLeakyBucketNegativeHits(t *testing.T) {
 			resp, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
 				Requests: []*guber.RateLimitReq{
 					{
-						Name:      "test_leaky_bucket",
-						UniqueKey: "account:1234",
+						Name:      "test_leaky_bucket_negative",
+						UniqueKey: "account:12345",
 						Algorithm: guber.Algorithm_LEAKY_BUCKET,
 						Duration:  guber.Second * 30,
 						Hits:      test.Hits,


### PR DESCRIPTION
This pull request fixes #156.

It's a simple change in both the tokenBucket and leakyBucket algorithms.
Unit tests for both changes were added.