### PR TITLE
Add version consistency check.

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --tags
 
       - name: Version consistency check
-        run: ./version-check.sh
+        run: ./check-version.sh
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: Fetch git tags
+        run: git fetch --tags
+
+      - name: Version consistency check
+        run: ./version-check.sh
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -5,20 +5,18 @@ on:
     types: [published]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Update 'version' file
-        run: |
-          export VERSION="${{ github.event.release.tag_name }}"
-          echo "$VERSION" > version
-          sed -i "s/^version:.*$/version: ${VERSION:1}/" charts/gubernator/Chart.yaml
-          sed -i "s/^appVersion:.*$/appVersion: ${VERSION:1}/" charts/gubernator/Chart.yaml
-   
+      - name: Fetch git tags
+        run: git fetch --tags
+
+      - name: Version consistency check
+        run: make version-check
+
       # Buildx Needs QEMU
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -28,13 +26,13 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           tags: |
@@ -45,15 +43,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-
-      # Commit the updated 'version' file
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          default_author: github_actions
-          message: 'Update version number'
-          branch: master
-          add: '["version", "charts/gubernator/Chart.yaml"]'
 
       # Publish the Helm chart
       - name: Publish Helm chart

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ jobs:
         run: git fetch --tags
 
       - name: Version consistency check
-        run: make version-check
+        run: ./check-version.sh
 
       # Buildx Needs QEMU
       - name: Set up QEMU

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,54 @@
+# Release Process
+Repository maintainers may be responsible for publishing new releases after
+functionality is merged.
+
+This document explains the release process for when a new version must be
+published.
+
+At a high level:
+* Merge PR to `master`.
+* Then, update version files in `master`.
+* Finally, publish GitHub Release.
+
+## Update Version Files
+Some files contain the current version in [semver](https://semver.org/) format,
+such as "2.0.0-rc.34".
+
+These files are:
+* `CHANGELOG`
+* `charts/helm/Chart.yaml`
+   * `version`
+   * `appVersion`
+* `version`
+
+It is necessary to manually update these files to match the target version.
+Commit and push directly to `master` branch.
+
+## Publish New GitHub Release
+Publish a GitHub release from github.com.
+
+Create a new tag with "v" prefix version, such as "v2.0.0-rc.34".
+
+In description, paste the same description added to `CHANGELOG`.
+
+Click "Publish Release".
+
+Publishing will launch an `on-release` GitHub Action to do the following:
+* Check version consistency.
+* Build Docker image.
+* Publish Docker image.
+* Publish Helm chart.
+
+More details on publishing GitHub releases:
+https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository.
+
+## Version Consistency Check
+The version consistency check is performed in both PR `on-pull-request` and
+`on-release`.  This will ensure the latest tag version matches the version
+found in the files described in [Update Version Files](#update-version-files).
+
+If the check fails, the workflow will abort with an error.  The developer can
+make the necessary changes indicated in the error message.
+
+Developers may call script `./version-check.sh` locally to verify changes
+before commit.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,12 @@ Publish a GitHub release from github.com.
 
 Create a new tag with "v" prefix version, such as "v2.0.0-rc.34".
 
-In description, paste the same description added to `CHANGELOG`.
+In description, paste the same description added to `CHANGELOG`.  For example,
+
+```markdown
+## What's Changed
+* Updated foobar by @Baliedge in #999.
+```
 
 Click "Publish Release".
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,15 @@ These files are:
    * `appVersion`
 * `version`
 
-It is necessary to manually update these files to match the target version.
+It is necessary to update these files to match the target version.
+
+Manually update `CHANGELOG`, then use script `update-version.sh` to easily
+update the remaining files.
+
+```
+$ ./update-version.sh 2.0.0-rc.35
+```
+
 Commit and push directly to `master` branch.
 
 ## Publish New GitHub Release
@@ -55,5 +63,5 @@ found in the files described in [Update Version Files](#update-version-files).
 If the check fails, the workflow will abort with an error.  The developer can
 make the necessary changes indicated in the error message.
 
-Developers may call script `./version-check.sh` locally to verify changes
+Developers may call script `./check-version.sh` locally to verify changes
 before commit.

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Check version consistency across repo.
 
 # Use git tag as reference version string.
 # Strip leading 'v'.

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Update version numbers stored in repo.
+
+version=$(echo $1 | sed 's/^v//')
+
+usage () {
+  echo "Usage: $0 <version>"
+  echo
+  echo "    version   Semver version string, such as: 2.0.1"
+}
+
+if [ -z "$version" ]; then
+  usage >&2
+  exit 1
+fi
+
+echo "Setting version: $version"
+
+echo "Updating version file..."
+echo v$version > version
+
+echo "Updating Helm chart..."
+sed -i '' 's/^version:.*$/version: '$version'/' charts/gubernator/Chart.yaml
+sed -i '' 's/^appVersion:.*$/appVersion: '$version'/' charts/gubernator/Chart.yaml

--- a/version-check.sh
+++ b/version-check.sh
@@ -4,30 +4,36 @@
 # Strip leading 'v'.
 VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) | sed -e 's/^v//')
 if [ -z "$VERSION" ]; then
-  >1 echo "Unable to determine version from git tags."
+  echo "Unable to determine version from git tags." >&1
   exit 1
 fi
 
-echo "Version: $VERSION"
+echo "Version tag: $VERSION"
+RETCODE=0
 
 # Check version file.
-grep "^$VERSION$" version || (
-  echo "version file mismatch: $VERSION <=> $(cat version)" >1
-  exit 1
-)
-echo 'version file OK'
+if [ ! "v$VERSION" = "$(cat version)" ]; then
+  echo "version file mismatch: v$VERSION <=> $(cat version)" >&1
+  RETCODE=1
+else
+  echo 'version file OK'
+fi
 
 # Check Helm chart.
 HELM_VERSION=$(yq .version charts/gubernator/Chart.yaml)
 if [ "$VERSION" != "$HELM_VERSION" ]; then
-  echo "Helm chart version mismatch: $VERSION <=> $HELM_VERSION" >1
-  exit 1
+  echo "Helm chart version mismatch: $VERSION <=> $HELM_VERSION" >&1
+  RETCODE=1
+else
+  echo 'Helm chart version OK'
 fi
-echo 'Helm chart version OK'
 
 HELM_APPVERSION=$(yq .appVersion charts/gubernator/Chart.yaml)
 if [ "$VERSION" != "$HELM_APPVERSION" ]; then
-  echo "Helm chart appVersion mismatch: $VERSION <=> $HELM_APPVERSION" >1
-  exit 1
+  echo "Helm chart appVersion mismatch: $VERSION <=> $HELM_APPVERSION" >&1
+  RETCODE=1
+else
+  echo 'Helm chart appVersion OK'
 fi
-echo 'Helm chart appVersion OK'
+
+exit $RETCODE

--- a/version-check.sh
+++ b/version-check.sh
@@ -4,7 +4,7 @@
 # Strip leading 'v'.
 VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) | sed -e 's/^v//')
 if [ -z "$VERSION" ]; then
-  echo "Unable to determine version from git tags." >&1
+  echo "Unable to determine version from git tags." >&2
   exit 1
 fi
 
@@ -13,7 +13,7 @@ RETCODE=0
 
 # Check version file.
 if [ ! "v$VERSION" = "$(cat version)" ]; then
-  echo "version file mismatch: v$VERSION <=> $(cat version)" >&1
+  echo "version file mismatch: v$VERSION <=> $(cat version)" >&2
   RETCODE=1
 else
   echo 'version file OK'
@@ -22,7 +22,7 @@ fi
 # Check Helm chart.
 HELM_VERSION=$(yq .version charts/gubernator/Chart.yaml)
 if [ "$VERSION" != "$HELM_VERSION" ]; then
-  echo "Helm chart version mismatch: $VERSION <=> $HELM_VERSION" >&1
+  echo "Helm chart version mismatch: $VERSION <=> $HELM_VERSION" >&2
   RETCODE=1
 else
   echo 'Helm chart version OK'
@@ -30,7 +30,7 @@ fi
 
 HELM_APPVERSION=$(yq .appVersion charts/gubernator/Chart.yaml)
 if [ "$VERSION" != "$HELM_APPVERSION" ]; then
-  echo "Helm chart appVersion mismatch: $VERSION <=> $HELM_APPVERSION" >&1
+  echo "Helm chart appVersion mismatch: $VERSION <=> $HELM_APPVERSION" >&2
   RETCODE=1
 else
   echo 'Helm chart appVersion OK'

--- a/version-check.sh
+++ b/version-check.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Use git tag as reference version string.
+# Strip leading 'v'.
+VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) | sed -e 's/^v//')
+if [ -z "$VERSION" ]; then
+  >1 echo "Unable to determine version from git tags."
+  exit 1
+fi
+
+echo "Version: $VERSION"
+
+# Check version file.
+grep "^$VERSION$" version || (
+  echo "version file mismatch: $VERSION <=> $(cat version)" >1
+  exit 1
+)
+echo 'version file OK'
+
+# Check Helm chart.
+HELM_VERSION=$(yq .version charts/gubernator/Chart.yaml)
+if [ "$VERSION" != "$HELM_VERSION" ]; then
+  echo "Helm chart version mismatch: $VERSION <=> $HELM_VERSION" >1
+  exit 1
+fi
+echo 'Helm chart version OK'
+
+HELM_APPVERSION=$(yq .appVersion charts/gubernator/Chart.yaml)
+if [ "$VERSION" != "$HELM_APPVERSION" ]; then
+  echo "Helm chart appVersion mismatch: $VERSION <=> $HELM_APPVERSION" >1
+  exit 1
+fi
+echo 'Helm chart appVersion OK'


### PR DESCRIPTION
Simplify the version update workflow.

## Original Workflow
### Manual Method
Previously, I have been manually updating the version by:
* Merge PR.
* Commit to `master` with changes to `version`, `CHANGELOG`, and Helm chart versions.
* Create a Github Release with a new version tag in format "v2.0.0-rc.34".
* Expect `on-release` action to launch and pass.

### Automated Method
However, there exists conflicting functionality in Github Actions to make automated updates to these files from the version tag.  This means that the workflow is assumed to be instead:
* Merge PR.
* Create Github Release with a new version tag.
* Expect `on-release` action to launch and pass.  This action updates the versions in files.

The apparent outcome is that the files are updated with the appropriate version, however the tag still points to the original commit.  When users pull the latest version, the versioning will not match.

In reality, the Github Action is failing when attempting to commit the changes.  Complains of missing branch `master`.

This error doesn't occur in Manual Method because no automated changes were needed because the correct versions were already updated, therefore nothing to commit.

## Change in Workflow
The workflow is documented in `RELEASE.md`.

Instead of automated file changes, the workflow should take the role of checking version state and allow the developer to make changes if anything fails.

This check happens in new script `./check-version.sh`.  It obtains the latest git tag and compares it against the versions inside files.

The script `./check-version.sh` is added to both `on-pull-request` and `on-release` actions to ensure consistency during PR development and at release time.

Workflow:
* Follow "Manual Method" above.
   * Instead of manually updating files, you may use helper script `./update-version.sh <version>` to update the required files with the new version.
* Expect `on-release` action to launch and pass.

The Docker and Helm resources are published only if `on-release` passes.
