### PR TITLE
Add environment variable to set minimum TLS version on server tls config

### DIFF
--- a/config.go
+++ b/config.go
@@ -521,7 +521,7 @@ func getEnvBool(log logrus.FieldLogger, name string) bool {
 func getEnvMinVersion(log logrus.FieldLogger, name string) uint16 {
 	v := os.Getenv(name)
 	if v == "" {
-		return tls.VersionTLS10
+		return tls.VersionTLS13
 	}
 	minVersion := map[string]uint16{
 		"1.0": tls.VersionTLS10,
@@ -531,8 +531,8 @@ func getEnvMinVersion(log logrus.FieldLogger, name string) uint16 {
 	}
 	version, ok := minVersion[v]
 	if !ok {
-		log.WithError(fmt.Errorf("unknown tls version: %s", v)).Errorf("while parsing '%s' as an min tls version, defaulting to 1.0", name)
-		return tls.VersionTLS10
+		log.WithError(fmt.Errorf("unknown tls version: %s", v)).Errorf("while parsing '%s' as an min tls version, defaulting to 1.3", name)
+		return tls.VersionTLS13
 	}
 	return version
 }

--- a/config.go
+++ b/config.go
@@ -336,6 +336,7 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile string) (DaemonConfig, 
 		setter.SetDefault(&conf.TLS.KeyFile, os.Getenv("GUBER_TLS_KEY"))
 		setter.SetDefault(&conf.TLS.CertFile, os.Getenv("GUBER_TLS_CERT"))
 		setter.SetDefault(&conf.TLS.AutoTLS, getEnvBool(log, "GUBER_TLS_AUTO"))
+		setter.SetDefault(&conf.TLS.MinVersion, getEnvMinVersion(log, "GUBER_TLS_MIN_VERSION"))
 
 		clientAuth := os.Getenv("GUBER_TLS_CLIENT_AUTH")
 		if clientAuth != "" {
@@ -515,6 +516,25 @@ func getEnvBool(log logrus.FieldLogger, name string) bool {
 		return false
 	}
 	return b
+}
+
+func getEnvMinVersion(log logrus.FieldLogger, name string) uint16 {
+	v := os.Getenv(name)
+	if v == "" {
+		return tls.VersionTLS10
+	}
+	minVersion := map[string]uint16{
+		"1.0": tls.VersionTLS10,
+		"1.1": tls.VersionTLS11,
+		"1.2": tls.VersionTLS12,
+		"1.3": tls.VersionTLS13,
+	}
+	version, ok := minVersion[v]
+	if !ok {
+		log.WithError(fmt.Errorf("unknown tls version: %s", v)).Errorf("while parsing '%s' as an min tls version, defaulting to 1.0", name)
+		return tls.VersionTLS10
+	}
+	return version
 }
 
 func getEnvInteger(log logrus.FieldLogger, name string) int {

--- a/example.conf
+++ b/example.conf
@@ -95,8 +95,8 @@ GUBER_ADVERTISE_ADDRESS=localhost:9990
 # provided gubernator will generate a CA and certs needed TLS.
 # GUBER_TLS_AUTO=false
 
-# Sets the minimum TLS version. If not set, defaults to 1.0
-# GUBER_TLS_MIN_VERSION=1.0
+# Sets the minimum TLS version. If not set, defaults to 1.3
+# GUBER_TLS_MIN_VERSION=1.3
 
 # Sets the Client Authentication type as defined in the golang standard 'crypto/tls' package.
 # Valid types are ('request-cert', 'verify-cert', 'require-any-cert', 'require-and-verify').

--- a/example.conf
+++ b/example.conf
@@ -95,6 +95,9 @@ GUBER_ADVERTISE_ADDRESS=localhost:9990
 # provided gubernator will generate a CA and certs needed TLS.
 # GUBER_TLS_AUTO=false
 
+# Sets the minimum TLS version. If not set, defaults to 1.0
+# GUBER_TLS_MIN_VERSION=1.0
+
 # Sets the Client Authentication type as defined in the golang standard 'crypto/tls' package.
 # Valid types are ('request-cert', 'verify-cert', 'require-any-cert', 'require-and-verify').
 # Use `require-and-verify` to achieve secure client authentication which will apply to all

--- a/tls.go
+++ b/tls.go
@@ -151,7 +151,7 @@ func SetupTLS(conf *TLSConfig) error {
 
 	minServerTLSVersion := conf.MinVersion
 	if minServerTLSVersion == 0 {
-		minServerTLSVersion = tls.VersionTLS10
+		minServerTLSVersion = tls.VersionTLS13
 	}
 
 	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))

--- a/tls.go
+++ b/tls.go
@@ -61,6 +61,9 @@ type TLSConfig struct {
 	//  the CaFile provided.
 	AutoTLS bool
 
+	// (Optional) Configures the MinVersion for ServerTLS. If not set, defaults to TLS 1.0
+	MinVersion uint16
+
 	// (Optional) Sets the Client Authentication type as defined in the 'tls' package.
 	// Defaults to tls.NoClientCert.See the standard library tls.ClientAuthType for valid values.
 	// If set to anything but tls.NoClientCert then SetupTLS() attempts to load ClientAuthCaFile,
@@ -146,6 +149,11 @@ func SetupTLS(conf *TLSConfig) error {
 		return nil
 	}
 
+	minServerTLSVersion := conf.MinVersion
+	if minServerTLSVersion == 0 {
+		minServerTLSVersion = tls.VersionTLS10
+	}
+
 	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))
 	conf.Logger.Info("Detected TLS Configuration")
 
@@ -171,7 +179,7 @@ func SetupTLS(conf *TLSConfig) error {
 			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 		},
 		ClientAuth: conf.ClientAuth,
-		MinVersion: tls.VersionTLS10,
+		MinVersion: minServerTLSVersion,
 		NextProtos: []string{
 			"h2", "http/1.1", // enable HTTP/2
 		},


### PR DESCRIPTION
This will allow folks to block usage of TLS 1.0 and TLS1.1 which have known vulnerabilities.