### PR TITLE
fix #161 token bucket fix for DURATION_IS_GrEGORIAN

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -228,12 +228,6 @@ func tokenBucketNewItem(ctx context.Context, s Store, c Cache, r *RateLimitReq) 
 		Remaining: r.Limit - r.Hits,
 		CreatedAt: now,
 	}
-	item := &CacheItem{
-		Algorithm: Algorithm_TOKEN_BUCKET,
-		Key:       r.HashKey(),
-		Value:     t,
-		ExpireAt:  expire,
-	}
 
 	// Add a new rate limit to the cache.
 	span.AddEvent("Add a new rate limit to the cache")
@@ -242,6 +236,13 @@ func tokenBucketNewItem(ctx context.Context, s Store, c Cache, r *RateLimitReq) 
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	item := &CacheItem{
+		Algorithm: Algorithm_TOKEN_BUCKET,
+		Key:       r.HashKey(),
+		Value:     t,
+		ExpireAt:  expire,
 	}
 
 	rl := &RateLimitResp{


### PR DESCRIPTION
Token bucket algorithm would reset "remaining" for a request within milliseconds when using behavior DURATION_IS_GREGORIAN.

This is happening because expiry calculation for behavior DURATION_IS_GREGORIAN, was calculated but never updated.

Raising a PR for this issue. #161 