### PR TITLE
Renamed gubernator pool to worker pool

### DIFF
--- a/config.go
+++ b/config.go
@@ -104,7 +104,7 @@ type Config struct {
 	// (Optional) The TLS config used when connecting to gubernator peers
 	PeerTLS *tls.Config
 
-	// (Optional) Number of worker goroutines to launch for request processing in GubernatorPool.
+	// (Optional) The number of go routine workers used to process concurrent rate limit requests
 	// Default is set to number of CPUs.
 	Workers int
 

--- a/workers.go
+++ b/workers.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package gubernator
 
-// Threadsafe worker pool for handling concurrent Gubernator requests.
+// Thread-safe worker pool for handling concurrent Gubernator requests.
 // Ensures requests are synchronized to avoid caching conflicts.
 // Handle concurrent requests by sharding cache key space across multiple
 // workers.
@@ -53,87 +53,86 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type GubernatorPool struct {
-	workers         []*poolWorker
+type WorkerPool struct {
+	hasher          workerHasher
+	workers         []*Worker
 	workerCacheSize int
-	hasher          ipoolHasher
 	hashRingStep    uint64
 	conf            *Config
 	done            chan struct{}
 }
 
-type poolWorker struct {
+type Worker struct {
 	name                string
 	conf                *Config
 	cache               Cache
 	getRateLimitRequest chan *request
-	storeRequest        chan poolStoreRequest
-	loadRequest         chan poolLoadRequest
-	addCacheItemRequest chan poolAddCacheItemRequest
-	getCacheItemRequest chan poolGetCacheItemRequest
+	storeRequest        chan workerStoreRequest
+	loadRequest         chan workerLoadRequest
+	addCacheItemRequest chan workerAddCacheItemRequest
+	getCacheItemRequest chan workerGetCacheItemRequest
 }
 
-type ipoolHasher interface {
-	// Return a 63-bit hash derived from input.
+type workerHasher interface {
+	// ComputeHash63 returns a 63-bit hash derived from input.
 	ComputeHash63(input string) uint64
 }
 
-// Standard implementation of ipoolHasher.
-type poolHasher struct {
-}
+// hasher is the default implementation of workerHasher.
+type hasher struct{}
 
 // Method request/response structs.
-type poolStoreRequest struct {
+type workerStoreRequest struct {
 	ctx      context.Context
-	response chan poolStoreResponse
+	response chan workerStoreResponse
 	out      chan<- *CacheItem
 }
 
-type poolStoreResponse struct{}
+type workerStoreResponse struct{}
 
-type poolLoadRequest struct {
+type workerLoadRequest struct {
 	ctx      context.Context
-	response chan poolLoadResponse
+	response chan workerLoadResponse
 	in       <-chan *CacheItem
 }
 
-type poolLoadResponse struct{}
+type workerLoadResponse struct{}
 
-type poolAddCacheItemRequest struct {
+type workerAddCacheItemRequest struct {
 	ctx      context.Context
-	response chan poolAddCacheItemResponse
+	response chan workerAddCacheItemResponse
 	item     *CacheItem
 }
 
-type poolAddCacheItemResponse struct {
+type workerAddCacheItemResponse struct {
 	exists bool
 }
 
-type poolGetCacheItemRequest struct {
+type workerGetCacheItemRequest struct {
 	ctx      context.Context
-	response chan poolGetCacheItemResponse
+	response chan workerGetCacheItemResponse
 	key      string
 }
 
-type poolGetCacheItemResponse struct {
+type workerGetCacheItemResponse struct {
 	item *CacheItem
 	ok   bool
 }
 
-var _ io.Closer = &GubernatorPool{}
-var _ ipoolHasher = &poolHasher{}
+var _ io.Closer = &WorkerPool{}
+var _ workerHasher = &hasher{}
 
-var poolWorkerCounter int64
+var workerCounter int64
 
-func NewGubernatorPool(conf *Config) *GubernatorPool {
+func NewWorkerPool(conf *Config) *WorkerPool {
 	setter.SetDefault(&conf.CacheSize, 50_000)
 
 	// Compute hashRingStep as interval between workers' 63-bit hash ranges.
 	// 64th bit is used here as a max value that is just out of range of 63-bit space to calculate the step.
-	chp := &GubernatorPool{
-		workers:         make([]*poolWorker, conf.Workers),
+	chp := &WorkerPool{
+		workers:         make([]*Worker, conf.Workers),
 		workerCacheSize: conf.CacheSize / conf.Workers,
-		hasher:          newPoolHasher(),
+		hasher:          newHasher(),
 		hashRingStep:    uint64(1<<63) / uint64(conf.Workers),
 		conf:            conf,
 		done:            make(chan struct{}),
@@ -148,39 +147,39 @@ func NewGubernatorPool(conf *Config) *GubernatorPool {
 	return chp
 }
 
-func newPoolHasher() *poolHasher {
-	return &poolHasher{}
+func newHasher() *hasher {
+	return &hasher{}
 }
 
-func (ph *poolHasher) ComputeHash63(input string) uint64 {
+func (ph *hasher) ComputeHash63(input string) uint64 {
 	return xxhash.ChecksumString64S(input, 0) >> 1
 }
 
-func (chp *GubernatorPool) Close() error {
+func (chp *WorkerPool) Close() error {
 	close(chp.done)
 	return nil
 }
 
 // Create a new pool worker instance.
-func (chp *GubernatorPool) newWorker() *poolWorker {
+func (chp *WorkerPool) newWorker() *Worker {
 	const commandChannelSize = 10000
 
-	worker := &poolWorker{
+	worker := &Worker{
 		cache:               chp.conf.CacheFactory(chp.workerCacheSize),
 		getRateLimitRequest: make(chan *request, commandChannelSize),
-		storeRequest:        make(chan poolStoreRequest, commandChannelSize),
-		loadRequest:         make(chan poolLoadRequest, commandChannelSize),
-		addCacheItemRequest: make(chan poolAddCacheItemRequest, commandChannelSize),
-		getCacheItemRequest: make(chan poolGetCacheItemRequest, commandChannelSize),
+		storeRequest:        make(chan workerStoreRequest, commandChannelSize),
+		loadRequest:         make(chan workerLoadRequest, commandChannelSize),
+		addCacheItemRequest: make(chan workerAddCacheItemRequest, commandChannelSize),
+		getCacheItemRequest: make(chan workerGetCacheItemRequest, commandChannelSize),
 	}
-	workerNumber := atomic.AddInt64(&poolWorkerCounter, 1) - 1
+	workerNumber := atomic.AddInt64(&workerCounter, 1) - 1
 	worker.name = strconv.FormatInt(workerNumber, 10)
 	return worker
 }
 
-// Returns the request channel associated with the key.
+// getWorker Returns the request channel associated with the key.
 // Hash the key, then lookup hash ring to find the worker.
-func (chp *GubernatorPool) getWorker(key string) *poolWorker {
+func (chp *WorkerPool) getWorker(key string) *Worker {
 	hash := chp.hasher.ComputeHash63(key)
 	idx := hash / chp.hashRingStep
 	return chp.workers[idx]
@@ -190,7 +189,7 @@ func (chp *GubernatorPool) getWorker(key string) *poolWorker {
 // Each worker maintains its own state.
 // A hash ring will distribute requests to an assigned worker by key.
 // See: getWorker()
-func (chp *GubernatorPool) worker(worker *poolWorker) {
+func (chp *WorkerPool) worker(worker *Worker) {
 	for {
 		// Dispatch requests from each channel.
 		select {
@@ -246,8 +245,8 @@ func (chp *GubernatorPool) worker(worker *poolWorker) {
 	}
 }
 
-// Send a GetRateLimit request to worker pool.
-func (chp *GubernatorPool) GetRateLimit(ctx context.Context, rlRequest *RateLimitReq) (retval *RateLimitResp, reterr error) {
+// GetRateLimit sends a GetRateLimit request to worker pool.
+func (chp *WorkerPool) GetRateLimit(ctx context.Context, rlRequest *RateLimitReq) (retval *RateLimitResp, reterr error) {
 	ctx = tracing.StartScope(ctx)
 	defer func() {
 		tracing.EndScope(ctx, reterr)
@@ -274,7 +273,7 @@ func (chp *GubernatorPool) GetRateLimit(ctx context.Context, rlRequest *RateLimi
 		return nil, ctx.Err()
 	}
 
-	poolWorkerQueueLength.WithLabelValues("GetRateLimit", worker.name).Observe(float64(len(worker.getRateLimitRequest)))
+	metricWorkerQueueLength.WithLabelValues("GetRateLimit", worker.name).Observe(float64(len(worker.getRateLimitRequest)))
 
 	// Wait for response.
 	span.AddEvent("Waiting for response...")
@@ -288,7 +287,7 @@ func (chp *GubernatorPool) GetRateLimit(ctx context.Context, rlRequest *RateLimi
 }
 
 // Handle request received by worker.
-func (chp *GubernatorPool) handleGetRateLimit(handlerRequest *request, cache Cache) {
+func (chp *WorkerPool) handleGetRateLimit(handlerRequest *request, cache Cache) {
 	ctx := tracing.StartScopeDebug(handlerRequest.ctx)
 	defer tracing.EndScope(ctx, nil)
 
@@ -317,7 +316,7 @@ func (chp *GubernatorPool) handleGetRateLimit(handlerRequest *request, cache Cac
 	default:
 		err = errors.Errorf("Invalid rate limit algorithm '%d'", handlerRequest.request.Algorithm)
 		trace.SpanFromContext(ctx).RecordError(err)
-		checkErrorCounter.WithLabelValues("Invalid algorithm").Add(1)
+		metricCheckErrorCounter.WithLabelValues("Invalid algorithm").Add(1)
 	}
 
 	handlerResponse := &response{
@@ -335,10 +334,10 @@ func (chp *GubernatorPool) handleGetRateLimit(handlerRequest *request, cache Cac
 	}
 }
 
-// Atomically load cache from persistent storage.
+// Load atomically loads cache from persistent storage.
 // Read from persistent storage.  Load into each appropriate worker's cache.
 // Workers are locked during this load operation to prevent race conditions.
-func (chp *GubernatorPool) Load(ctx context.Context) (reterr error) {
+func (chp *WorkerPool) Load(ctx context.Context) (reterr error) {
 	ctx = tracing.StartScope(ctx)
 	defer func() {
 		tracing.EndScope(ctx, reterr)
@@ -351,15 +350,15 @@ func (chp *GubernatorPool) Load(ctx context.Context) (reterr error) {
 
 	type loadChannel struct {
 		ch       chan *CacheItem
-		worker   *poolWorker
-		respChan chan poolLoadResponse
+		worker   *Worker
+		respChan chan workerLoadResponse
 	}
 
 	// Map request channel hash to load channel.
-	loadChMap := map[*poolWorker]loadChannel{}
+	loadChMap := map[*Worker]loadChannel{}
 
 	// Send each item to assigned channel's cache.
-mainloop:
+MAIN:
 	for {
 		var item *CacheItem
 		var ok bool
@@ -367,7 +366,7 @@ mainloop:
 		select {
 		case item, ok = <-ch:
 			if !ok {
-				break mainloop
+				break MAIN
 			}
 			// Successfully received item.
 
@@ -384,12 +383,12 @@ mainloop:
 			loadCh = loadChannel{
 				ch:       make(chan *CacheItem),
 				worker:   worker,
-				respChan: make(chan poolLoadResponse),
+				respChan: make(chan workerLoadResponse),
 			}
 			loadChMap[worker] = loadCh
 
 			// Tie up the worker while loading.
-			worker.loadRequest <- poolLoadRequest{
+			worker.loadRequest <- workerLoadRequest{
 				ctx:      ctx,
 				response: loadCh.respChan,
 				in:       loadCh.ch,
@@ -426,11 +425,11 @@ mainloop:
 	return nil
 }
 
-func (chp *GubernatorPool) handleLoad(request poolLoadRequest, cache Cache) {
+func (chp *WorkerPool) handleLoad(request workerLoadRequest, cache Cache) {
 	ctx := tracing.StartScopeDebug(request.ctx)
 	defer tracing.EndScope(ctx, nil)
 
-mainloop:
+MAIN:
 	for {
 		var item *CacheItem
 		var ok bool
@@ -438,7 +437,7 @@ mainloop:
 		select {
 		case item, ok = <-request.in:
 			if !ok {
-				break mainloop
+				break MAIN
 			}
 			// Successfully received item.
 
@@ -450,7 +449,7 @@ mainloop:
 		cache.Add(item)
 	}
 
-	response := poolLoadResponse{}
+	response := workerLoadResponse{}
 
 	select {
 	case request.response <- response:
@@ -462,10 +461,10 @@ mainloop:
 	}
 }
 
-// Atomically store cache to persistent storage.
+// Store atomically stores cache to persistent storage.
 // Save all workers' caches to persistent storage.
 // Workers are locked during this store operation to prevent race conditions.
-func (chp *GubernatorPool) Store(ctx context.Context) (reterr error) {
+func (chp *WorkerPool) Store(ctx context.Context) (reterr error) {
 	ctx = tracing.StartScope(ctx)
 	defer func() {
 		tracing.EndScope(ctx, reterr)
@@ -478,13 +477,13 @@ func (chp *GubernatorPool) Store(ctx context.Context) (reterr error) {
 	for _, worker := range chp.workers {
 		wg.Add(1)
 
-		go func(ctx context.Context, worker *poolWorker) {
+		go func(ctx context.Context, worker *Worker) {
 			ctx = tracing.StartNamedScope(ctx, fmt.Sprintf("%p", worker))
 			defer tracing.EndScope(ctx, nil)
 			defer wg.Done()
 
-			respChan := make(chan poolStoreResponse)
-			req := poolStoreRequest{
+			respChan := make(chan workerStoreResponse)
+			req := workerStoreRequest{
 				ctx:      ctx,
 				response: respChan,
 				out:      out,
@@ -530,7 +529,7 @@ func (chp *GubernatorPool) Store(ctx context.Context) (reterr error) {
 	return nil
 }
 
-func (chp *GubernatorPool) handleStore(request poolStoreRequest, cache Cache) {
+func (chp *WorkerPool) handleStore(request workerStoreRequest, cache Cache) {
 	ctx := tracing.StartScopeDebug(request.ctx)
 	defer tracing.EndScope(ctx, nil)
 
@@ -546,7 +545,7 @@ func (chp *GubernatorPool) handleStore(request poolStoreRequest, cache Cache) {
 		}
 	}
 
-	response := poolStoreResponse{}
+	response := workerStoreResponse{}
 
 	select {
 	case request.response <- response:
@@ -558,16 +557,16 @@ func (chp *GubernatorPool) handleStore(request poolStoreRequest, cache Cache) {
 	}
 }
 
-// Add to worker's cache.
-func (chp *GubernatorPool) AddCacheItem(ctx context.Context, key string, item *CacheItem) (reterr error) {
+// AddCacheItem adds an item to the worker's cache.
+func (chp *WorkerPool) AddCacheItem(ctx context.Context, key string, item *CacheItem) (reterr error) {
 	ctx = tracing.StartScope(ctx)
 	defer func() {
 		tracing.EndScope(ctx, reterr)
 	}()
 
-	respChan := make(chan poolAddCacheItemResponse)
+	respChan := make(chan workerAddCacheItemResponse)
 	worker := chp.getWorker(key)
-	req := poolAddCacheItemRequest{
+	req := workerAddCacheItemRequest{
 		ctx:      ctx,
 		response: respChan,
 		item:     item,
@@ -576,7 +575,7 @@ func (chp *GubernatorPool) AddCacheItem(ctx context.Context, key string, item *C
 	select {
 	case worker.addCacheItemRequest <- req:
 		// Successfully sent request.
-		poolWorkerQueueLength.WithLabelValues("AddCacheItem", worker.name).Observe(float64(len(worker.addCacheItemRequest)))
+		metricWorkerQueueLength.WithLabelValues("AddCacheItem", worker.name).Observe(float64(len(worker.addCacheItemRequest)))
 
 		select {
 		case <-respChan:
@@ -594,12 +593,12 @@ func (chp *GubernatorPool) AddCacheItem(ctx context.Context, key string, item *C
 	}
 }
 
-func (chp *GubernatorPool) handleAddCacheItem(request poolAddCacheItemRequest, cache Cache) {
+func (chp *WorkerPool) handleAddCacheItem(request workerAddCacheItemRequest, cache Cache) {
 	ctx := tracing.StartScopeDebug(request.ctx)
 	defer tracing.EndScope(ctx, nil)
 
 	exists := cache.Add(request.item)
-	response := poolAddCacheItemResponse{exists}
+	response := workerAddCacheItemResponse{exists}
 
 	select {
 	case request.response <- response:
@@ -611,16 +610,16 @@ func (chp *GubernatorPool) handleAddCacheItem(request poolAddCacheItemRequest, c
 	}
 }
 
-// Get item from worker's cache.
-func (chp *GubernatorPool) GetCacheItem(ctx context.Context, key string) (item *CacheItem, found bool, reterr error) {
+// GetCacheItem gets item from worker's cache.
+func (chp *WorkerPool) GetCacheItem(ctx context.Context, key string) (item *CacheItem, found bool, reterr error) {
 	ctx = tracing.StartScope(ctx)
 	defer func() {
 		tracing.EndScope(ctx, reterr)
 	}()
 
-	respChan := make(chan poolGetCacheItemResponse)
+	respChan := make(chan workerGetCacheItemResponse)
 	worker := chp.getWorker(key)
-	req := poolGetCacheItemRequest{
+	req := workerGetCacheItemRequest{
 		ctx:      ctx,
 		response: respChan,
 		key:      key,
@@ -628,8 +627,8 @@ func (chp *GubernatorPool) GetCacheItem(ctx context.Context, key string) (item *
 
 	select {
 	case worker.getCacheItemRequest <- req:
-		// Successfully sent requst.
-		poolWorkerQueueLength.WithLabelValues("GetCacheItem", worker.name).Observe(float64(len(worker.getCacheItemRequest)))
+		// Successfully sent request.
+		metricWorkerQueueLength.WithLabelValues("GetCacheItem", worker.name).Observe(float64(len(worker.getCacheItemRequest)))
 
 		select {
 		case resp := <-respChan:
@@ -647,12 +646,12 @@ func (chp *GubernatorPool) GetCacheItem(ctx context.Context, key string) (item *
 	}
 }
 
-func (chp *GubernatorPool) handleGetCacheItem(request poolGetCacheItemRequest, cache Cache) {
+func (chp *WorkerPool) handleGetCacheItem(request workerGetCacheItemRequest, cache Cache) {
 	ctx := tracing.StartScopeDebug(request.ctx)
 	defer tracing.EndScope(ctx, nil)
 
 	item, ok := cache.GetItem(request.key)
-	response := poolGetCacheItemResponse{item, ok}
+	response := workerGetCacheItemResponse{item, ok}
 
 	select {
 	case request.response <- response:

--- a/workers_internal_test.go
+++ b/workers_internal_test.go
@@ -24,17 +24,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockPoolHasher struct {
+type MockHasher struct {
 	mock.Mock
 }
 
-func (m *MockPoolHasher) ComputeHash63(input string) uint64 {
+func (m *MockHasher) ComputeHash63(input string) uint64 {
 	args := m.Called(input)
 	retval, _ := args.Get(0).(uint64)
 	return retval
 }
 
-func TestGubernatorPoolInternal(t *testing.T) {
+func TestWorkersInternal(t *testing.T) {
 	t.Run("getWorker()", func(t *testing.T) {
 		const concurrency = 32
 		conf := &Config{
@@ -57,9 +57,9 @@ func TestGubernatorPoolInternal(t *testing.T) {
 
 		for _, testCase := range testCases {
 			t.Run(testCase.Name, func(t *testing.T) {
-				pool := NewGubernatorPool(conf)
+				pool := NewWorkerPool(conf)
 				defer pool.Close()
-				mockHasher := &MockPoolHasher{}
+				mockHasher := &MockHasher{}
 				pool.hasher = mockHasher
 
 				// Setup mocks.

--- a/workers_test.go
+++ b/workers_test.go
@@ -63,7 +63,7 @@ func TestGubernatorPool(t *testing.T) {
 					Workers: testCase.workers,
 				}
 				conf.SetDefaults()
-				chp := guber.NewGubernatorPool(conf)
+				chp := guber.NewWorkerPool(conf)
 
 				// Mock Loader.
 				fakeLoadCh := make(chan *guber.CacheItem, NumCacheItems)
@@ -96,7 +96,7 @@ func TestGubernatorPool(t *testing.T) {
 					Workers: testCase.workers,
 				}
 				require.NoError(t, conf.SetDefaults())
-				chp := guber.NewGubernatorPool(conf)
+				chp := guber.NewWorkerPool(conf)
 
 				// Mock Loader.
 				mockLoader.On("Save", mock.Anything).Once().Return(nil).


### PR DESCRIPTION
### Purpose
I always found `GubernatorPool` to be confusing, so I renamed it to `WorkerPool` which should make it clearer what the pool is for.

### Implementation
* This PR depends on #180 
* Prefixed all the global Prometheus metrics with `metric` which clearly identifies each as such.
 