### PR TITLE
Add Service Monitor to helm chart

### DIFF
--- a/charts/gubernator/templates/hpa.yaml
+++ b/charts/gubernator/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gubernator.autoscaling.enabled -}}
 {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
@@ -25,3 +26,4 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.gubernator.autoscaling.cpuAverageUtilization }}
+{{- end }}

--- a/charts/gubernator/templates/servicemonitor.yaml
+++ b/charts/gubernator/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.gubernator.serviceMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gubernator.fullname" . }}
+  labels:
+  {{- include "gubernator.labels" . | nindent 4 }}
+  annotations:
+  {{- include "gubernator.annotations" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: http
+      path: "/metrics"
+      {{- if .Values.gubernator.serviceMonitor.interval }}
+      interval: {{ .Values.gubernator.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.gubernator.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.gubernator.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.gubernator.serviceMonitor.relabellings }}
+      relabelings: {{- toYaml .Values.gubernator.serviceMonitor.relabellings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.gubernator.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.gubernator.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{- include "gubernator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/gubernator/values.yaml
+++ b/charts/gubernator/values.yaml
@@ -50,3 +50,8 @@ gubernator:
     requests:
       cpu: 100m
       memory: 150Mi
+
+  serviceMonitor:
+    create: true
+    interval: 5s
+    scrapeTimeout: 5s

--- a/charts/gubernator/values.yaml
+++ b/charts/gubernator/values.yaml
@@ -52,6 +52,6 @@ gubernator:
       memory: 150Mi
 
   serviceMonitor:
-    create: true
+    create: false
     interval: 5s
     scrapeTimeout: 5s


### PR DESCRIPTION
Hi, I Hope you're doing OK. I've tried to add a `serviceMonitor` template to make metrics scraping easier.

There was also a tiny issue with `hpa` which I've included in this PR. Please let me know if you find any issues with this.

Thank you.