### PR TITLE
Fix startup error due to OTel dependency upgrade.

### DIFF
--- a/cmd/gubernator/main.go
+++ b/cmd/gubernator/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mailgun/holster/v4/tracing"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"k8s.io/klog"
 )
 


### PR DESCRIPTION
```
msg="during tracing.NewResource()" category=gubernator error="error in resource.Merge on resources index 0: cannot merge resource due to conflicting Schema URL"
```

https://github.com/mailgun/gubernator/issues/195