### PR TITLE
test: fix TestPeerClientShutdown

### DIFF
--- a/peer_client_test.go
+++ b/peer_client_test.go
@@ -64,7 +64,7 @@ func TestPeerClientShutdown(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(threads)
 			// Spawn a whole bunch of concurrent requests to test shutdown in various states
-			for i := 0; i < threads; i++ {
+			for j := 0; j < threads; j++ {
 				go func() {
 					defer wg.Done()
 					ctx := context.Background()


### PR DESCRIPTION
Fix test failure https://github.com/mailgun/gubernator/actions/runs/7023893758/job/19111445772?pr=204#step:9:319

```
panic: test timed out after 10m0s
running tests:
	TestPeerClientShutdown (9m57s)
	TestPeerClientShutdown/Batching (9m57s)

goroutine 4053 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:2259 +0x1fc
created by time.goFunc
	/opt/hostedtoolcache/go/1.21.4/x64/src/time/sleep.go:176 +0x45

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc0009d2000, {0x2a05153, 0x16}, 0x2add728)
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:1649 +0x856
testing.runTests.func1(0x0?)
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:2054 +0x85
testing.tRunner(0xc0009d2000, 0xc0008c97c8)
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:1595 +0x239
testing.runTests(0xc0004a40a0?, {0x3c6e900, 0x26, 0x26}, {0xc0007f0c78?, 0xc0007f0a80?, 0x3c860c0?})
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:2052 +0x897
testing.(*M).Run(0xc0004a40a0)
	/opt/hostedtoolcache/go/1.21.4/x64/src/testing/testing.go:1925 +0xb58
github.com/mailgun/gubernator/v2_test.TestMain(0x9a901f7990fb9af6?)
	/home/runner/work/gubernator/gubernator/functional_test.go:60 +0x131
main.main()
	_testmain.go:133 +0x308
```