### PR TITLE
Change global behavior

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -50,7 +50,7 @@ jobs:
           skip-cache: true
 
       - name: Test
-        run: go test -v -race -p=1 -count=1
+        run: go test -v -race -p=1 -count=1 -tags holster_test_mode
   go-bench:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint: $(GOLANGCI_LINT)
 
 .PHONY: test
 test:
-	(go test -v -race -p=1 -count=1 -coverprofile coverage.out ./...; ret=$$?; \
+	(go test -v -race -p=1 -count=1 -tags holster_test_mode -coverprofile coverage.out ./...; ret=$$?; \
 		go tool cover -func coverage.out; \
 		go tool cover -html coverage.out -o coverage.html; \
 		exit $$ret)

--- a/algorithms.go
+++ b/algorithms.go
@@ -388,16 +388,17 @@ func leakyBucket(ctx context.Context, s Store, c Cache, r *RateLimitReq) (resp *
 
 		// If requested hits takes the remainder
 		if int64(b.Remaining) == r.Hits {
-			b.Remaining -= float64(r.Hits)
-			rl.Remaining = 0
+			b.Remaining = 0
+			rl.Remaining = int64(b.Remaining)
 			rl.ResetTime = now + (rl.Limit-rl.Remaining)*int64(rate)
 			return rl, nil
 		}
 
-		// If requested is more than available, then return over the limit
-		// without updating the bucket.
+		// If requested is more than available, drain bucket in order to converge as everything is returning OVER_LIMIT.
 		if r.Hits > int64(b.Remaining) {
 			metricOverLimitCounter.Add(1)
+			b.Remaining = 0
+			rl.Remaining = int64(b.Remaining)
 			rl.Status = Status_OVER_LIMIT
 			if HasBehavior(r.Behavior, Behavior_DRAIN_OVER_LIMIT) {
 				// DRAIN_OVER_LIMIT behavior drains the remaining counter.

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -68,6 +68,15 @@ func PeerAt(idx int) gubernator.PeerInfo {
 	return peers[idx]
 }
 
+// FindOwningPeer finds the peer which owns the rate limit with the provided name and unique key
+func FindOwningPeer(name, key string) (gubernator.PeerInfo, error) {
+	p, err := daemons[0].V1Server.GetPeer(context.Background(), name+"_"+key)
+	if err != nil {
+		return gubernator.PeerInfo{}, err
+	}
+	return p.Info(), nil
+}
+
 // DaemonAt returns a specific daemon
 func DaemonAt(idx int) *gubernator.Daemon {
 	return daemons[idx]

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -77,6 +77,38 @@ func FindOwningPeer(name, key string) (gubernator.PeerInfo, error) {
 	return p.Info(), nil
 }
 
+// FindOwningDaemon finds the daemon which owns the rate limit with the provided name and unique key
+func FindOwningDaemon(name, key string) (*gubernator.Daemon, error) {
+	p, err := daemons[0].V1Server.GetPeer(context.Background(), name+"_"+key)
+	if err != nil {
+		return &gubernator.Daemon{}, err
+	}
+
+	for i, d := range daemons {
+		if d.PeerInfo.GRPCAddress == p.Info().GRPCAddress {
+			return daemons[i], nil
+		}
+	}
+	return &gubernator.Daemon{}, errors.New("unable to find owning daemon")
+}
+
+// ListNonOwningDaemons returns a list of daemons in the cluster that do not own the rate limit
+// for the name and key provided.
+func ListNonOwningDaemons(name, key string) ([]*gubernator.Daemon, error) {
+	owner, err := FindOwningDaemon(name, key)
+	if err != nil {
+		return []*gubernator.Daemon{}, err
+	}
+
+	var daemons []*gubernator.Daemon
+	for _, d := range GetDaemons() {
+		if d.PeerInfo.GRPCAddress != owner.PeerInfo.GRPCAddress {
+			daemons = append(daemons, d)
+		}
+	}
+	return daemons, nil
+}
+
 // DaemonAt returns a specific daemon
 func DaemonAt(idx int) *gubernator.Daemon {
 	return daemons[idx]
@@ -121,6 +153,7 @@ func StartWith(localPeers []gubernator.PeerInfo) error {
 		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		d, err := gubernator.SpawnDaemon(ctx, gubernator.DaemonConfig{
 			Logger:            logrus.WithField("instance", peer.GRPCAddress),
+			InstanceID:        peer.GRPCAddress,
 			GRPCListenAddress: peer.GRPCAddress,
 			HTTPListenAddress: peer.HTTPAddress,
 			DataCenter:        peer.DataCenter,
@@ -136,12 +169,15 @@ func StartWith(localPeers []gubernator.PeerInfo) error {
 			return errors.Wrapf(err, "while starting server for addr '%s'", peer.GRPCAddress)
 		}
 
-		// Add the peers and daemons to the package level variables
-		peers = append(peers, gubernator.PeerInfo{
+		p := gubernator.PeerInfo{
 			GRPCAddress: d.GRPCListeners[0].Addr().String(),
 			HTTPAddress: d.HTTPListener.Addr().String(),
 			DataCenter:  peer.DataCenter,
-		})
+		}
+		d.PeerInfo = p
+
+		// Add the peers and daemons to the package level variables
+		peers = append(peers, p)
 		daemons = append(daemons, d)
 	}
 

--- a/config.go
+++ b/config.go
@@ -71,6 +71,8 @@ type BehaviorConfig struct {
 
 // Config for a gubernator instance
 type Config struct {
+	InstanceID string
+
 	// (Required) A list of GRPC servers to register our instance with
 	GRPCServers []*grpc.Server
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -35,20 +35,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/resolver"
 	json "google.golang.org/protobuf/encoding/protojson"
 )
-
-var algos = []struct {
-	Name      string
-	Algorithm guber.Algorithm
-}{
-	{Name: "Token bucket", Algorithm: guber.Algorithm_TOKEN_BUCKET},
-	{Name: "Leaky bucket", Algorithm: guber.Algorithm_LEAKY_BUCKET},
-}
 
 // Setup and shutdown the mock gubernator cluster for the entire test suite
 func TestMain(m *testing.M) {
@@ -410,8 +398,8 @@ func TestDrainOverLimit(t *testing.T) {
 		},
 	}
 
-	for idx, algoCase := range algos {
-		t.Run(algoCase.Name, func(t *testing.T) {
+	for idx, algoCase := range []guber.Algorithm{guber.Algorithm_TOKEN_BUCKET, guber.Algorithm_LEAKY_BUCKET} {
+		t.Run(guber.Algorithm_name[int32(algoCase)], func(t *testing.T) {
 			for _, test := range tests {
 				ctx := context.Background()
 				t.Run(test.Name, func(t *testing.T) {
@@ -420,7 +408,7 @@ func TestDrainOverLimit(t *testing.T) {
 							{
 								Name:      "test_drain_over_limit",
 								UniqueKey: fmt.Sprintf("account:1234:%d", idx),
-								Algorithm: algoCase.Algorithm,
+								Algorithm: algoCase,
 								Behavior:  guber.Behavior_DRAIN_OVER_LIMIT,
 								Duration:  guber.Second * 30,
 								Hits:      test.Hits,
@@ -440,6 +428,49 @@ func TestDrainOverLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTokenBucketRequestMoreThanAvailable(t *testing.T) {
+	defer clock.Freeze(clock.Now()).Unfreeze()
+
+	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
+	require.NoError(t, err)
+
+	sendHit := func(status guber.Status, remain int64, hit int64) *guber.RateLimitResp {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+		defer cancel()
+		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+			Requests: []*guber.RateLimitReq{
+				{
+					Name:      "test_token_more_than_available",
+					UniqueKey: "account:123456",
+					Algorithm: guber.Algorithm_TOKEN_BUCKET,
+					Duration:  guber.Millisecond * 1000,
+					Hits:      hit,
+					Limit:     2000,
+				},
+			},
+		})
+		require.NoError(t, err, hit)
+		assert.Equal(t, "", resp.Responses[0].Error)
+		assert.Equal(t, status, resp.Responses[0].Status)
+		assert.Equal(t, remain, resp.Responses[0].Remaining)
+		assert.Equal(t, int64(2000), resp.Responses[0].Limit)
+		return resp.Responses[0]
+	}
+
+	// Use half of the bucket
+	sendHit(guber.Status_UNDER_LIMIT, 1000, 1000)
+
+	// Ask for more than the bucket has and the remainder is still 1000.
+	// See NOTE in algorithms.go
+	sendHit(guber.Status_OVER_LIMIT, 1000, 1500)
+
+	// Now other clients can ask for some of the remaining until we hit our limit
+	sendHit(guber.Status_UNDER_LIMIT, 500, 500)
+	sendHit(guber.Status_UNDER_LIMIT, 100, 400)
+	sendHit(guber.Status_UNDER_LIMIT, 0, 100)
+	sendHit(guber.Status_OVER_LIMIT, 0, 1)
 }
 
 func TestLeakyBucket(t *testing.T) {
@@ -701,7 +732,7 @@ func TestLeakyBucketGregorian(t *testing.T) {
 			Hits:      1,
 			Remaining: 58,
 			Status:    guber.Status_UNDER_LIMIT,
-			Sleep:     clock.Second,
+			Sleep:     clock.Millisecond * 1200,
 		},
 		{
 			Name:      "third hit; leak one hit",
@@ -711,7 +742,12 @@ func TestLeakyBucketGregorian(t *testing.T) {
 		},
 	}
 
+	// Truncate to the nearest minute
 	now := clock.Now()
+	now = now.Truncate(1 * time.Minute)
+	// So we don't start on the minute boundary
+	now = now.Add(time.Millisecond * 100)
+
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			resp, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
@@ -812,6 +848,50 @@ func TestLeakyBucketNegativeHits(t *testing.T) {
 	}
 }
 
+func TestLeakyBucketRequestMoreThanAvailable(t *testing.T) {
+	// Freeze time so we don't leak during the test
+	defer clock.Freeze(clock.Now()).Unfreeze()
+
+	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
+	require.NoError(t, err)
+
+	sendHit := func(status guber.Status, remain int64, hits int64) *guber.RateLimitResp {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+		defer cancel()
+		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+			Requests: []*guber.RateLimitReq{
+				{
+					Name:      "test_leaky_more_than_available",
+					UniqueKey: "account:123456",
+					Algorithm: guber.Algorithm_LEAKY_BUCKET,
+					Duration:  guber.Millisecond * 1000,
+					Hits:      hits,
+					Limit:     2000,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", resp.Responses[0].Error)
+		assert.Equal(t, status, resp.Responses[0].Status)
+		assert.Equal(t, remain, resp.Responses[0].Remaining)
+		assert.Equal(t, int64(2000), resp.Responses[0].Limit)
+		return resp.Responses[0]
+	}
+
+	// Use half of the bucket
+	sendHit(guber.Status_UNDER_LIMIT, 1000, 1000)
+
+	// Ask for more than the rate limit has and the remainder is still 1000.
+	// See NOTE in algorithms.go
+	sendHit(guber.Status_OVER_LIMIT, 1000, 1500)
+
+	// Now other clients can ask for some of the remaining until we hit our limit
+	sendHit(guber.Status_UNDER_LIMIT, 500, 500)
+	sendHit(guber.Status_UNDER_LIMIT, 100, 400)
+	sendHit(guber.Status_UNDER_LIMIT, 0, 100)
+	sendHit(guber.Status_OVER_LIMIT, 0, 1)
+}
+
 func TestMissingFields(t *testing.T) {
 	client, errs := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
 	require.Nil(t, errs)
@@ -876,12 +956,16 @@ func TestMissingFields(t *testing.T) {
 }
 
 func TestGlobalRateLimits(t *testing.T) {
-	peer := cluster.PeerAt(0).GRPCAddress
-	client, errs := guber.DialV1Server(peer, nil)
-	require.NoError(t, errs)
+	const (
+		name = "test_global"
+		key  = "account:12345"
+	)
 
-	sendHit := func(status guber.Status, remain int64, i int) string {
-		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*5)
+	peers, err := cluster.ListNonOwningDaemons(name, key)
+	require.NoError(t, err)
+
+	sendHit := func(client guber.V1Client, status guber.Status, hits int64, remain int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		defer cancel()
 		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
 			Requests: []*guber.RateLimitReq{
@@ -890,52 +974,47 @@ func TestGlobalRateLimits(t *testing.T) {
 					UniqueKey: "account:12345",
 					Algorithm: guber.Algorithm_TOKEN_BUCKET,
 					Behavior:  guber.Behavior_GLOBAL,
-					Duration:  guber.Second * 3,
-					Hits:      1,
+					Duration:  guber.Minute * 3,
+					Hits:      hits,
 					Limit:     5,
 				},
 			},
 		})
-		require.NoError(t, err, i)
-		assert.Equal(t, "", resp.Responses[0].Error, i)
-		assert.Equal(t, status, resp.Responses[0].Status, i)
-		assert.Equal(t, remain, resp.Responses[0].Remaining, i)
-		assert.Equal(t, int64(5), resp.Responses[0].Limit, i)
-
-		// ensure that we have a canonical host
-		assert.NotEmpty(t, resp.Responses[0].Metadata["owner"])
-
-		// name/key should ensure our connected peer is NOT the owner,
-		// the peer we are connected to should forward requests asynchronously to the owner.
-		assert.NotEqual(t, peer, resp.Responses[0].Metadata["owner"])
-
-		return resp.Responses[0].Metadata["owner"]
+		require.NoError(t, err)
+		assert.Equal(t, "", resp.Responses[0].Error)
+		assert.Equal(t, remain, resp.Responses[0].Remaining)
+		assert.Equal(t, status, resp.Responses[0].Status)
+		assert.Equal(t, int64(5), resp.Responses[0].Limit)
 	}
-
 	// Our first hit should create the request on the peer and queue for async forward
-	sendHit(guber.Status_UNDER_LIMIT, 4, 1)
+	sendHit(peers[0].MustClient(), guber.Status_UNDER_LIMIT, 1, 4)
 
 	// Our second should be processed as if we own it since the async forward hasn't occurred yet
-	sendHit(guber.Status_UNDER_LIMIT, 3, 2)
+	sendHit(peers[0].MustClient(), guber.Status_UNDER_LIMIT, 2, 2)
 
 	testutil.UntilPass(t, 20, clock.Millisecond*200, func(t testutil.TestingT) {
-		// Inspect our metrics, ensure they collected the counts we expected during this test
-		d := cluster.DaemonAt(0)
-		metricsURL := fmt.Sprintf("http://%s/metrics", d.Config().HTTPListenAddress)
-		m := getMetricRequest(t, metricsURL, "gubernator_global_send_duration_count")
+		// Inspect peers metrics, ensure the peer sent the global rate limit to the owner
+		metricsURL := fmt.Sprintf("http://%s/metrics", peers[0].Config().HTTPListenAddress)
+		m, err := getMetricRequest(metricsURL, "gubernator_global_send_duration_count")
+		assert.NoError(t, err)
 		assert.Equal(t, 1, int(m.Value))
-
-		// Expect one peer (the owning peer) to indicate a broadcast.
-		var broadcastCount int
-		for i := 0; i < cluster.NumOfDaemons(); i++ {
-			d := cluster.DaemonAt(i)
-			metricsURL := fmt.Sprintf("http://%s/metrics", d.Config().HTTPListenAddress)
-			m := getMetricRequest(t, metricsURL, "gubernator_broadcast_duration_count")
-			broadcastCount += int(m.Value)
-		}
-
-		assert.Equal(t, 1, broadcastCount)
 	})
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
+
+	require.NoError(t, waitForBroadcast(clock.Second*3, owner, 1))
+
+	// Check different peers, they should have gotten the broadcast from the owner
+	sendHit(peers[1].MustClient(), guber.Status_UNDER_LIMIT, 0, 2)
+	sendHit(peers[2].MustClient(), guber.Status_UNDER_LIMIT, 0, 2)
+
+	// Non owning peer should calculate the rate limit remaining before forwarding
+	// to the owner.
+	sendHit(peers[3].MustClient(), guber.Status_UNDER_LIMIT, 2, 0)
+
+	require.NoError(t, waitForBroadcast(clock.Second*3, owner, 2))
+
+	sendHit(peers[4].MustClient(), guber.Status_OVER_LIMIT, 1, 0)
 }
 
 func TestGlobalRateLimitsPeerOverLimit(t *testing.T) {
@@ -944,14 +1023,13 @@ func TestGlobalRateLimitsPeerOverLimit(t *testing.T) {
 		key  = "account:12345"
 	)
 
-	// Make a connection to a peer in the cluster which does not own this rate limit
-	client, err := getClientToNonOwningPeer(name, key)
+	peers, err := cluster.ListNonOwningDaemons(name, key)
 	require.NoError(t, err)
 
-	sendHit := func(expectedStatus guber.Status, hits int) {
-		ctx, cancel := context.WithTimeout(context.Background(), clock.Hour*5)
+	sendHit := func(expectedStatus guber.Status, hits int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		defer cancel()
-		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+		resp, err := peers[0].MustClient().GetRateLimits(ctx, &guber.GetRateLimitsReq{
 			Requests: []*guber.RateLimitReq{
 				{
 					Name:      name,
@@ -959,7 +1037,7 @@ func TestGlobalRateLimitsPeerOverLimit(t *testing.T) {
 					Algorithm: guber.Algorithm_TOKEN_BUCKET,
 					Behavior:  guber.Behavior_GLOBAL,
 					Duration:  guber.Minute * 5,
-					Hits:      1,
+					Hits:      hits,
 					Limit:     2,
 				},
 			},
@@ -968,17 +1046,19 @@ func TestGlobalRateLimitsPeerOverLimit(t *testing.T) {
 		assert.Equal(t, "", resp.Responses[0].GetError())
 		assert.Equal(t, expectedStatus, resp.Responses[0].GetStatus())
 	}
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
 
 	// Send two hits that should be processed by the owner and the broadcast to peer, depleting the remaining
 	sendHit(guber.Status_UNDER_LIMIT, 1)
 	sendHit(guber.Status_UNDER_LIMIT, 1)
 	// Wait for the broadcast from the owner to the peer
-	time.Sleep(time.Second * 3)
+	require.NoError(t, waitForBroadcast(clock.Second*3, owner, 1))
 	// Since the remainder is 0, the peer should set OVER_LIMIT instead of waiting for the owner
 	// to respond with OVER_LIMIT.
 	sendHit(guber.Status_OVER_LIMIT, 1)
 	// Wait for the broadcast from the owner to the peer
-	time.Sleep(time.Second * 3)
+	require.NoError(t, waitForBroadcast(clock.Second*3, owner, 2))
 	// The status should still be OVER_LIMIT
 	sendHit(guber.Status_OVER_LIMIT, 0)
 }
@@ -989,12 +1069,11 @@ func TestGlobalRateLimitsPeerOverLimitLeaky(t *testing.T) {
 		key  = "account:12345"
 	)
 
-	// Make a connection to a peer in the cluster which does not own this rate limit
-	client, err := getClientToNonOwningPeer(name, key)
+	peers, err := cluster.ListNonOwningDaemons(name, key)
 	require.NoError(t, err)
 
-	sendHit := func(expectedStatus guber.Status, hits int) {
-		ctx, cancel := context.WithTimeout(context.Background(), clock.Hour*5)
+	sendHit := func(client guber.V1Client, expectedStatus guber.Status, hits int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		defer cancel()
 		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
 			Requests: []*guber.RateLimitReq{
@@ -1004,7 +1083,7 @@ func TestGlobalRateLimitsPeerOverLimitLeaky(t *testing.T) {
 					Algorithm: guber.Algorithm_LEAKY_BUCKET,
 					Behavior:  guber.Behavior_GLOBAL,
 					Duration:  guber.Minute * 5,
-					Hits:      1,
+					Hits:      hits,
 					Limit:     2,
 				},
 			},
@@ -1013,18 +1092,228 @@ func TestGlobalRateLimitsPeerOverLimitLeaky(t *testing.T) {
 		assert.Equal(t, "", resp.Responses[0].GetError())
 		assert.Equal(t, expectedStatus, resp.Responses[0].GetStatus())
 	}
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
 
-	sendHit(guber.Status_UNDER_LIMIT, 1)
-	sendHit(guber.Status_UNDER_LIMIT, 1)
-	time.Sleep(time.Second * 3)
-	sendHit(guber.Status_OVER_LIMIT, 1)
+	// Send two hits that should be processed by the owner and the broadcast to peer, depleting the remaining
+	sendHit(peers[0].MustClient(), guber.Status_UNDER_LIMIT, 1)
+	sendHit(peers[0].MustClient(), guber.Status_UNDER_LIMIT, 1)
+	// Wait for the broadcast from the owner to the peers
+	require.NoError(t, waitForBroadcast(clock.Second*3, owner, 1))
+	// Ask a different peer if the status is over the limit
+	sendHit(peers[1].MustClient(), guber.Status_OVER_LIMIT, 1)
 }
 
-func getMetricRequest(t testutil.TestingT, url string, name string) *model.Sample {
-	resp, err := http.Get(url)
+func TestGlobalRequestMoreThanAvailable(t *testing.T) {
+	const (
+		name = "test_global_more_than_available"
+		key  = "account:123456"
+	)
+
+	peers, err := cluster.ListNonOwningDaemons(name, key)
 	require.NoError(t, err)
+
+	sendHit := func(client guber.V1Client, expectedStatus guber.Status, hits int64, remaining int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+		defer cancel()
+		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+			Requests: []*guber.RateLimitReq{
+				{
+					Name:      name,
+					UniqueKey: key,
+					Algorithm: guber.Algorithm_LEAKY_BUCKET,
+					Behavior:  guber.Behavior_GLOBAL,
+					Duration:  guber.Minute * 1_000,
+					Hits:      hits,
+					Limit:     100,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "", resp.Responses[0].GetError())
+		assert.Equal(t, expectedStatus, resp.Responses[0].GetStatus())
+	}
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
+
+	prev, err := getBroadcastCount(owner)
+	require.NoError(t, err)
+
+	// Ensure GRPC has connections to each peer before we start, as we want
+	// the actual test requests to happen quite fast.
+	for _, p := range peers {
+		sendHit(p.MustClient(), guber.Status_UNDER_LIMIT, 0, 100)
+	}
+
+	// Send a request for 50 hits from each non owning peer in the cluster. These requests
+	// will be queued and sent to the owner as accumulated hits. As a result of the async nature
+	// of `Behavior_GLOBAL` rate limit requests spread across peers like this will be allowed to
+	// over-consume their resource within the rate limit window until the owner is updated and
+	// a broadcast to all peers is received.
+	//
+	// The maximum number of resources that can be over-consumed can be calculated by multiplying
+	// the remainder by the number of peers in the cluster. For example: If you have a remainder of 100
+	// and a cluster of 10 instances, then the maximum over-consumed resource is 1,000. If you need
+	// a more accurate remaining calculation, and wish to avoid over consuming a resource, then do
+	// not use `Behavior_GLOBAL`.
+	for _, p := range peers {
+		sendHit(p.MustClient(), guber.Status_UNDER_LIMIT, 50, 50)
+	}
+
+	// Wait for the broadcast from the owner to the peers
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+1))
+
+	// We should be over the limit
+	sendHit(peers[0].MustClient(), guber.Status_OVER_LIMIT, 1, 0)
+}
+
+func TestGlobalNegativeHits(t *testing.T) {
+	const (
+		name = "test_global_negative_hits"
+		key  = "account:12345"
+	)
+
+	peers, err := cluster.ListNonOwningDaemons(name, key)
+	require.NoError(t, err)
+
+	sendHit := func(client guber.V1Client, status guber.Status, hits int64, remaining int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+		defer cancel()
+		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+			Requests: []*guber.RateLimitReq{
+				{
+					Name:      name,
+					UniqueKey: key,
+					Algorithm: guber.Algorithm_TOKEN_BUCKET,
+					Behavior:  guber.Behavior_GLOBAL,
+					Duration:  guber.Minute * 100,
+					Hits:      hits,
+					Limit:     2,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "", resp.Responses[0].GetError())
+		assert.Equal(t, status, resp.Responses[0].GetStatus())
+		assert.Equal(t, remaining, resp.Responses[0].Remaining)
+	}
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
+	prev, err := getBroadcastCount(owner)
+	require.NoError(t, err)
+
+	// Send a negative hit on a rate limit with no hits
+	sendHit(peers[0].MustClient(), guber.Status_UNDER_LIMIT, -1, 3)
+
+	// Wait for the negative remaining to propagate
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+1))
+
+	// Send another negative hit to a different peer
+	sendHit(peers[1].MustClient(), guber.Status_UNDER_LIMIT, -1, 4)
+
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+2))
+
+	// Should have 4 in the remainder
+	sendHit(peers[2].MustClient(), guber.Status_UNDER_LIMIT, 4, 0)
+
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+3))
+
+	sendHit(peers[3].MustClient(), guber.Status_UNDER_LIMIT, 0, 0)
+}
+
+func TestGlobalResetRemaining(t *testing.T) {
+	const (
+		name = "test_global_reset"
+		key  = "account:123456"
+	)
+
+	peers, err := cluster.ListNonOwningDaemons(name, key)
+	require.NoError(t, err)
+
+	sendHit := func(client guber.V1Client, expectedStatus guber.Status, hits int64, remaining int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+		defer cancel()
+		resp, err := client.GetRateLimits(ctx, &guber.GetRateLimitsReq{
+			Requests: []*guber.RateLimitReq{
+				{
+					Name:      name,
+					UniqueKey: key,
+					Algorithm: guber.Algorithm_LEAKY_BUCKET,
+					Behavior:  guber.Behavior_GLOBAL,
+					Duration:  guber.Minute * 1_000,
+					Hits:      hits,
+					Limit:     100,
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "", resp.Responses[0].GetError())
+		assert.Equal(t, expectedStatus, resp.Responses[0].GetStatus())
+		assert.Equal(t, remaining, resp.Responses[0].Remaining)
+	}
+	owner, err := cluster.FindOwningDaemon(name, key)
+	require.NoError(t, err)
+	prev, err := getBroadcastCount(owner)
+	require.NoError(t, err)
+
+	for _, p := range peers {
+		sendHit(p.MustClient(), guber.Status_UNDER_LIMIT, 50, 50)
+	}
+
+	// Wait for the broadcast from the owner to the peers
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+1))
+
+	// We should be over the limit and remaining should be zero
+	sendHit(peers[0].MustClient(), guber.Status_OVER_LIMIT, 1, 0)
+
+	// Now reset the remaining
+	ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
+	defer cancel()
+	resp, err := peers[0].MustClient().GetRateLimits(ctx, &guber.GetRateLimitsReq{
+		Requests: []*guber.RateLimitReq{
+			{
+				Name:      name,
+				UniqueKey: key,
+				Algorithm: guber.Algorithm_LEAKY_BUCKET,
+				Behavior:  guber.Behavior_GLOBAL | guber.Behavior_RESET_REMAINING,
+				Duration:  guber.Minute * 1_000,
+				Hits:      0,
+				Limit:     100,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 100, resp.Responses[0].Remaining)
+
+	// Wait for the reset to propagate.
+	require.NoError(t, waitForBroadcast(clock.Second*10, owner, prev+2))
+
+	// Check a different peer to ensure remaining has been reset
+	resp, err = peers[1].MustClient().GetRateLimits(ctx, &guber.GetRateLimitsReq{
+		Requests: []*guber.RateLimitReq{
+			{
+				Name:      name,
+				UniqueKey: key,
+				Algorithm: guber.Algorithm_LEAKY_BUCKET,
+				Behavior:  guber.Behavior_GLOBAL,
+				Duration:  guber.Minute * 1_000,
+				Hits:      0,
+				Limit:     100,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 100, resp.Responses[0].Remaining)
+
+}
+
+func getMetricRequest(url string, name string) (*model.Sample, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
-	return getMetric(t, resp.Body, name)
+	return getMetric(resp.Body, name)
 }
 
 func TestChangeLimit(t *testing.T) {
@@ -1261,6 +1550,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestLeakyBucketDivBug(t *testing.T) {
+	// Freeze time so we don't leak during the test
 	defer clock.Freeze(clock.Now()).Unfreeze()
 
 	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
@@ -1408,7 +1698,7 @@ func TestGetPeerRateLimits(t *testing.T) {
 
 // TODO: Add a test for sending no rate limits RateLimitReqList.RateLimits = nil
 
-func getMetric(t testutil.TestingT, in io.Reader, name string) *model.Sample {
+func getMetric(in io.Reader, name string) (*model.Sample, error) {
 	dec := expfmt.SampleDecoder{
 		Dec: expfmt.NewDecoder(in, expfmt.FmtText),
 		Opts: &expfmt.DecodeOptions{
@@ -1423,87 +1713,58 @@ func getMetric(t testutil.TestingT, in io.Reader, name string) *model.Sample {
 		if err == io.EOF {
 			break
 		}
-		assert.NoError(t, err)
+		if err != nil {
+			return nil, err
+		}
 		all = append(all, smpls...)
 	}
 
 	for _, s := range all {
 		if strings.Contains(s.Metric.String(), name) {
-			return s
+			return s, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-type staticBuilder struct{}
-
-var _ resolver.Builder = (*staticBuilder)(nil)
-
-func (sb *staticBuilder) Scheme() string {
-	return "static"
-}
-
-func (sb *staticBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
-	var resolverAddrs []resolver.Address
-	for _, address := range strings.Split(target.Endpoint(), ",") {
-		resolverAddrs = append(resolverAddrs, resolver.Address{
-			Addr:       address,
-			ServerName: address,
-		})
-	}
-	if err := cc.UpdateState(resolver.State{Addresses: resolverAddrs}); err != nil {
-		return nil, err
-	}
-	return &staticResolver{cc: cc}, nil
-}
-
-// newStaticBuilder returns a builder which returns a staticResolver that tells GRPC
-// to connect a specific peer in the cluster.
-func newStaticBuilder() resolver.Builder {
-	return &staticBuilder{}
-}
-
-type staticResolver struct {
-	cc resolver.ClientConn
-}
-
-func (sr *staticResolver) ResolveNow(_ resolver.ResolveNowOptions) {}
-
-func (sr *staticResolver) Close() {}
-
-var _ resolver.Resolver = (*staticResolver)(nil)
-
-// findNonOwningPeer returns peer info for a peer in the cluster which does not
-// own the rate limit for the name and key provided.
-func findNonOwningPeer(name, key string) (guber.PeerInfo, error) {
-	owner, err := cluster.FindOwningPeer(name, key)
+// getBroadcastCount returns the current broadcast count for use with waitForBroadcast()
+// TODO: Replace this with something else, we can call and reset via HTTP/GRPC calls in gubernator v3
+func getBroadcastCount(d *guber.Daemon) (int, error) {
+	m, err := getMetricRequest(fmt.Sprintf("http://%s/metrics", d.Config().HTTPListenAddress),
+		"gubernator_broadcast_duration_count")
 	if err != nil {
-		return guber.PeerInfo{}, err
+		return 0, err
 	}
 
-	for _, p := range cluster.GetPeers() {
-		if p.HashKey() != owner.HashKey() {
-			return p, nil
+	return int(m.Value), nil
+}
+
+// waitForBroadcast waits until the broadcast count for the daemon passed
+// changes to the expected value. Returns an error if the expected value is
+// not found before the context is cancelled.
+func waitForBroadcast(timeout clock.Duration, d *guber.Daemon, expect int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		m, err := getMetricRequest(fmt.Sprintf("http://%s/metrics", d.Config().HTTPListenAddress),
+			"gubernator_broadcast_duration_count")
+		if err != nil {
+			return err
+		}
+
+		// It's possible a broadcast occurred twice if waiting for multiple peer to
+		// forward updates to the owner.
+		if int(m.Value) >= expect {
+			// Give the nodes some time to process the broadcasts
+			clock.Sleep(clock.Millisecond * 500)
+			return nil
+		}
+
+		select {
+		case <-clock.After(time.Millisecond * 800):
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
-	return guber.PeerInfo{}, fmt.Errorf("unable to find non-owning peer in '%d' node cluster",
-		len(cluster.GetPeers()))
-}
-
-// getClientToNonOwningPeer returns a connection to a peer in the cluster which does not own
-// the rate limit for the name and key provided.
-func getClientToNonOwningPeer(name, key string) (guber.V1Client, error) {
-	p, err := findNonOwningPeer(name, key)
-	if err != nil {
-		return nil, err
-	}
-	conn, err := grpc.DialContext(context.Background(),
-		fmt.Sprintf("static:///%s", p.GRPCAddress),
-		grpc.WithResolvers(newStaticBuilder()),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, err
-	}
-	return guber.NewV1Client(conn), nil
-
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -1014,17 +1014,10 @@ func TestGlobalRateLimitsPeerOverLimitLeaky(t *testing.T) {
 		assert.Equal(t, expectedStatus, resp.Responses[0].GetStatus())
 	}
 
-	// Send two hits that should be processed by the owner and the broadcast to peer, depleting the remaining
 	sendHit(guber.Status_UNDER_LIMIT, 1)
 	sendHit(guber.Status_UNDER_LIMIT, 1)
-	// Wait for the broadcast from the owner to the peer
 	time.Sleep(time.Second * 3)
-	// Since the peer must wait for the owner to say it's over the limit, this will return under the limit.
-	sendHit(guber.Status_UNDER_LIMIT, 1)
-	// Wait for the broadcast from the owner to the peer
-	time.Sleep(time.Second * 3)
-	// The status should now be OVER_LIMIT
-	sendHit(guber.Status_OVER_LIMIT, 0)
+	sendHit(guber.Status_OVER_LIMIT, 1)
 }
 
 func getMetricRequest(t testutil.TestingT, url string, name string) *model.Sample {

--- a/global.go
+++ b/global.go
@@ -98,6 +98,11 @@ func (gm *globalManager) runAsyncHits() {
 			key := r.HashKey()
 			_, ok := hits[key]
 			if ok {
+				// If any of our hits includes a request to RESET_REMAINING
+				// ensure the owning peer gets this behavior
+				if HasBehavior(r.Behavior, Behavior_RESET_REMAINING) {
+					SetBehavior(&hits[key].Behavior, Behavior_RESET_REMAINING, true)
+				}
 				hits[key].Hits += r.Hits
 			} else {
 				hits[key] = r
@@ -145,7 +150,6 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 			gm.log.WithError(err).Errorf("while getting peer for hash key '%s'", r.HashKey())
 			continue
 		}
-
 		p, ok := peerRequests[peer.Info().GRPCAddress]
 		if ok {
 			p.req.Requests = append(p.req.Requests, r)

--- a/global.go
+++ b/global.go
@@ -21,14 +21,13 @@ import (
 
 	"github.com/mailgun/holster/v4/syncutil"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/proto"
 )
 
 // globalManager manages async hit queue and updates peers in
 // the cluster periodically when a global rate limit we own updates.
 type globalManager struct {
 	hitsQueue                chan *RateLimitReq
-	updatesQueue             chan *RateLimitReq
+	broadcastQueue           chan *UpdatePeerGlobal
 	wg                       syncutil.WaitGroup
 	conf                     BehaviorConfig
 	log                      FieldLogger
@@ -41,11 +40,11 @@ type globalManager struct {
 
 func newGlobalManager(conf BehaviorConfig, instance *V1Instance) *globalManager {
 	gm := globalManager{
-		log:          instance.log,
-		hitsQueue:    make(chan *RateLimitReq, conf.GlobalBatchLimit),
-		updatesQueue: make(chan *RateLimitReq, conf.GlobalBatchLimit),
-		instance:     instance,
-		conf:         conf,
+		log:            instance.log,
+		hitsQueue:      make(chan *RateLimitReq, conf.GlobalBatchLimit),
+		broadcastQueue: make(chan *UpdatePeerGlobal, conf.GlobalBatchLimit),
+		instance:       instance,
+		conf:           conf,
 		metricGlobalSendDuration: prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:       "gubernator_global_send_duration",
 			Help:       "The duration of GLOBAL async sends in seconds.",
@@ -74,8 +73,12 @@ func (gm *globalManager) QueueHit(r *RateLimitReq) {
 	gm.hitsQueue <- r
 }
 
-func (gm *globalManager) QueueUpdate(r *RateLimitReq) {
-	gm.updatesQueue <- r
+func (gm *globalManager) QueueUpdate(req *RateLimitReq, resp *RateLimitResp) {
+	gm.broadcastQueue <- &UpdatePeerGlobal{
+		Key:       req.HashKey(),
+		Algorithm: req.Algorithm,
+		Status:    resp,
+	}
 }
 
 // runAsyncHits collects async hit requests in a forever loop,
@@ -179,18 +182,18 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 // and in a periodic frequency determined by GlobalSyncWait.
 func (gm *globalManager) runBroadcasts() {
 	var interval = NewInterval(gm.conf.GlobalSyncWait)
-	updates := make(map[string]*RateLimitReq)
+	updates := make(map[string]*UpdatePeerGlobal)
 
 	gm.wg.Until(func(done chan struct{}) bool {
 		select {
-		case r := <-gm.updatesQueue:
-			updates[r.HashKey()] = r
+		case updateReq := <-gm.broadcastQueue:
+			updates[updateReq.Key] = updateReq
 
 			// Send the hits if we reached our batch limit
 			if len(updates) >= gm.conf.GlobalBatchLimit {
 				gm.metricBroadcastCounter.WithLabelValues("queue_full").Inc()
 				gm.broadcastPeers(context.Background(), updates)
-				updates = make(map[string]*RateLimitReq)
+				updates = make(map[string]*UpdatePeerGlobal)
 				return true
 			}
 
@@ -204,7 +207,7 @@ func (gm *globalManager) runBroadcasts() {
 			if len(updates) != 0 {
 				gm.metricBroadcastCounter.WithLabelValues("timer").Inc()
 				gm.broadcastPeers(context.Background(), updates)
-				updates = make(map[string]*RateLimitReq)
+				updates = make(map[string]*UpdatePeerGlobal)
 			} else {
 				gm.metricGlobalQueueLength.Set(0)
 			}
@@ -216,30 +219,14 @@ func (gm *globalManager) runBroadcasts() {
 }
 
 // broadcastPeers broadcasts global rate limit statuses to all other peers
-func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]*RateLimitReq) {
+func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]*UpdatePeerGlobal) {
 	defer prometheus.NewTimer(gm.metricBroadcastDuration).ObserveDuration()
 	var req UpdatePeerGlobalsReq
 
 	gm.metricGlobalQueueLength.Set(float64(len(updates)))
 
 	for _, r := range updates {
-		// Copy the original since we are removing the GLOBAL behavior
-		rl := proto.Clone(r).(*RateLimitReq)
-		// We are only sending the status of the rate limit so, we
-		// clear the behavior flag, so we don't get queued for update again.
-		SetBehavior(&rl.Behavior, Behavior_GLOBAL, false)
-		rl.Hits = 0
-
-		status, err := gm.instance.getLocalRateLimit(ctx, rl)
-		if err != nil {
-			gm.log.WithError(err).Errorf("while getting local rate limit for: '%s'", rl.HashKey())
-			continue
-		}
-		req.Globals = append(req.Globals, &UpdatePeerGlobal{
-			Algorithm: rl.Algorithm,
-			Key:       rl.HashKey(),
-			Status:    status,
-		})
+		req.Globals = append(req.Globals, r)
 	}
 
 	fan := syncutil.NewFanOut(gm.conf.GlobalPeerRequestsConcurrency)

--- a/global.go
+++ b/global.go
@@ -163,6 +163,7 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 		fan.Run(func(in interface{}) error {
 			p := in.(*pair)
 			ctx, cancel := context.WithTimeout(context.Background(), gm.conf.GlobalTimeout)
+			gm.log.Infof("calling owner of key: %s with hits: %d", p.req.Requests[0].UniqueKey, p.req.Requests[0].Hits)
 			_, err := p.client.GetPeerRateLimits(ctx, &p.req)
 			cancel()
 
@@ -239,6 +240,7 @@ func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]
 		fan.Run(func(in interface{}) error {
 			peer := in.(*PeerClient)
 			ctx, cancel := context.WithTimeout(ctx, gm.conf.GlobalTimeout)
+			gm.log.Infof("calling peer of key: %s with hits: %d", req.Globals[0].Key, req.Globals[0].Status.Remaining)
 			_, err := peer.UpdatePeerGlobals(ctx, &req)
 			cancel()
 

--- a/global.go
+++ b/global.go
@@ -163,7 +163,6 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 		fan.Run(func(in interface{}) error {
 			p := in.(*pair)
 			ctx, cancel := context.WithTimeout(context.Background(), gm.conf.GlobalTimeout)
-			gm.log.Infof("calling owner of key: %s with hits: %d", p.req.Requests[0].UniqueKey, p.req.Requests[0].Hits)
 			_, err := p.client.GetPeerRateLimits(ctx, &p.req)
 			cancel()
 
@@ -240,7 +239,6 @@ func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]
 		fan.Run(func(in interface{}) error {
 			peer := in.(*PeerClient)
 			ctx, cancel := context.WithTimeout(ctx, gm.conf.GlobalTimeout)
-			gm.log.Infof("calling peer of key: %s with hits: %d", req.Globals[0].Key, req.Globals[0].Status.Remaining)
 			_, err := peer.UpdatePeerGlobals(ctx, &req)
 			cancel()
 

--- a/gubernator.go
+++ b/gubernator.go
@@ -432,7 +432,7 @@ func (s *V1Instance) UpdatePeerGlobals(ctx context.Context, r *UpdatePeerGlobals
 	now := MillisecondNow()
 	for _, g := range r.Globals {
 		item := &CacheItem{
-			ExpireAt:  g.Status.ResetTime + 100000,
+			ExpireAt:  g.Status.ResetTime + 1000, // account for clock drift from owner where `ResetTime` might already be less than current time of the local machine. 
 			Algorithm: g.Algorithm,
 			Key:       g.Key,
 		}

--- a/interval_test.go
+++ b/interval_test.go
@@ -18,9 +18,8 @@ package gubernator_test
 
 import (
 	"testing"
-	"time"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/mailgun/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,18 +27,18 @@ import (
 
 func TestInterval(t *testing.T) {
 	t.Run("Happy path", func(t *testing.T) {
-		interval := gubernator.NewInterval(10 * time.Millisecond)
+		interval := gubernator.NewInterval(10 * clock.Millisecond)
 		defer interval.Stop()
 		interval.Next()
 
 		assert.Empty(t, interval.C)
 
-		time.Sleep(10 * time.Millisecond)
+		clock.Sleep(10 * clock.Millisecond)
 
 		// Wait for tick.
 		select {
 		case <-interval.C:
-		case <-time.After(100 * time.Millisecond):
+		case <-clock.After(100 * clock.Millisecond):
 			require.Fail(t, "timeout")
 		}
 	})


### PR DESCRIPTION
### Purpose
To change how `GLOBAL` behavior operates. Previously, the owner of the rate limit would broadcast the computed result of the rate limit to other peers, and the computed result from the owner is returned to clients who submit hits to a peer. However, after some great feed back on #218 and #216 It has become clear that we should instead allow the local peers to compute the result of the request based on the hits broadcast by the owning peer.

In the new behavior a peer will compute the result of the rate limit request and immediately return that computed result. This means that the non owning peer will compute the result with the current `Remaining` value it currently has in it's cache. To put it another way, the peer cache will no longer hold the computed result from the owner. 

In order to facilitate this change, I've added many more tests around global functionality which should help ensure we don't break behavior going forward.

### Implementation
* The global broadcaster will now use the new `DRAIN_OVER_LIMIT` behavior when accepting peer rate limits. This allows many peers to send a burst of hits to the owner while still updating the remaining even if the requested hits is more that is available. See https://github.com/mailgun/gubernator/pull/218#discussion_r1483302784
* Added Tests to ensure the "do not update remaining if requesting more than is remaining" semantic does not change.
* Added `cluster.ListNonOwningDaemons()` to assist in global testing
* Added `cluster.FindOwningDaemon()` to assist in global testing
* Added `waitForBroadcast()` to functional testing suite tools so we can remove the sleep statements.
* Moved `newStaticBuilder()` to daemon.go
* Added `MustClient()` and `Client()` to `gubernator.Daemon` to make it easier to find and send RPC requests to a daemon instance.
* `RESET_REMAINING` now works correctly with global behavior
* Fixed an issue where the peer that received the rate limit would broadcast the rate limit to all peers instead of waiting for the owning peer to broadcast.
* Now correctly populating `Daemon.InstanceID` and Added `InstanceID` to the `Instance`
* Bumped Lint Version
* Misc Test fixes and improvements. `TestLeakyBucketGregorian` should no longer occasionally fail the test suite.

This PR replaces #218 and #216 but keeps the commits from those PR's

Thank you to these wonderful people, for giving great feed back and working on this!
* @philipgough 
* @miparnisari 
* @elbuo8