### PR TITLE
fixes issue when a config file is not specified

### DIFF
--- a/cmd/gubernator-cli/main.go
+++ b/cmd/gubernator-cli/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"strings"
@@ -89,9 +90,12 @@ func main() {
 		cmdLine := strings.Join(os.Args[1:], " ")
 		logrus.WithContext(ctx).Info("Command line: " + cmdLine)
 
-		configFileReader, err := os.Open(configFile)
-		if err != nil {
-			return fmt.Errorf("while opening config file: %s", err)
+		var configFileReader io.Reader
+		if configFile != "" {
+			configFileReader, err = os.Open(configFile)
+			if err != nil {
+				log.WithError(err).Fatal("while opening config file")
+			}
 		}
 		conf, err := guber.SetupDaemonConfig(log, configFileReader)
 		if err != nil {

--- a/cmd/gubernator/main.go
+++ b/cmd/gubernator/main.go
@@ -74,9 +74,12 @@ func main() {
 	}
 
 	// Read our config from the environment or optional environment config file
-	configFileReader, err := os.Open(configFile)
-	if err != nil {
-		log.WithError(err).Fatal("while opening config file")
+	var configFileReader io.Reader
+	if configFile != "" {
+		configFileReader, err = os.Open(configFile)
+		if err != nil {
+			log.WithError(err).Fatal("while opening config file")
+		}
 	}
 	conf, err := gubernator.SetupDaemonConfig(logrus.StandardLogger(), configFileReader)
 	checkErr(err, "while getting config")

--- a/config_test.go
+++ b/config_test.go
@@ -38,3 +38,10 @@ func TestDefaultInstanceId(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, daemonConfig.InstanceID)
 }
+
+func TestNoConfigFile(t *testing.T) {
+	os.Clearenv()
+	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, daemonConfig.InstanceID)
+}


### PR DESCRIPTION
This PR addresses a bug introduced in #214. Previously, it was possible to run the program without specifying a config file. However, due to the current implementation, attempting to open a nonexistent file (empty string) results in the program terminating unexpectedly.